### PR TITLE
Fix typo in cryptography detector

### DIFF
--- a/bin/steps/cryptography
+++ b/bin/steps/cryptography
@@ -20,7 +20,7 @@ source $BIN_DIR/utils
 bpwatch start libffi_install
 
 # If pylibmc exists within requirements, use vendored cryptography.
-if (pip-grep -s requirements.txt cffi crytography &> /dev/null) then
+if (pip-grep -s requirements.txt cffi cryptography &> /dev/null) then
 
   if [ -d ".heroku/vendor/lib/libffi-3.1.1" ]; then
     export LIBFFI=$(pwd)/vendor


### PR DESCRIPTION
Fix a typo "bin/steps/cryptography" which  enables detection of cryptography requirement.
