### PR TITLE
Heroku stack bump from cedar to cedar-14

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -39,7 +39,7 @@ VIRTUALENV_LOC=".heroku/venv"
 LEGACY_TRIGGER="lib/python2.7"
 
 DEFAULT_PYTHON_VERSION="python-2.7.10"
-DEFAULT_PYTHON_STACK="cedar"
+DEFAULT_PYTHON_STACK="cedar-14"
 PYTHON_EXE="/app/.heroku/python/bin/python"
 PIP_VERSION="7.1.2"
 SETUPTOOLS_VERSION="18.3.2"


### PR DESCRIPTION
# What
To reflect Ubuntu 14.04 version we have do use a proper stack.

# Details

A bit of background on this issue. The Cloudfoundry Python build-pack has a step to auto-detect the use of GDAL from the requirements.txt. If it detects it, it will attempt to download a pre-compiled version of GDAL from an S3 bucket. The pre-compiled versions which are being downloaded are actually compiled against Heroku stack versions, and the default is to download from the stack cedar which corresponds to an Ubuntu 10.04 based installation. Ubuntu 10.04 is now end-of-life and as such, we actually want to download the 14.04 equivalent which is cedar-14

# How to test 
- put GDAL in requirements.txt
- `cf push APPNAME -b https://github.com/combor/python-buildpack.git#heroku_stack_fix`