### PR TITLE
Add Graphviz support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -236,6 +236,9 @@ sub-env $BIN_DIR/steps/geo-libs
 # GDAL support.
 source $BIN_DIR/steps/gdal
 
+# Graphviz support.
+source $BIN_DIR/steps/graphviz
+
 # Install dependencies with Pip.
 source $BIN_DIR/steps/pip-install
 

--- a/bin/steps/graphviz
+++ b/bin/steps/graphviz
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# This script serves as the Graphviz build step of the
+# [**Python Buildpack**](https://github.com/heroku/heroku-buildpack-python)
+# compiler.
+#
+# A [buildpack](https://devcenter.heroku.com/articles/buildpacks) is an
+# adapter between a Python application and Heroku's runtime.
+#
+# This script is invoked by [`bin/compile`](/).
+
+# The location of the pre-compiled cryptography binary.
+VENDORED_GRAPHVIZ="https://s3-us-west-2.amazonaws.com/mfenniak-graphviz/graphviz-2.30.tgz"
+
+PKG_CONFIG_PATH="/app/.heroku/vendor/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+# Syntax sugar.
+source $BIN_DIR/utils
+
+bpwatch start graphviz_install
+
+# If Graphviz exists within requirements, use vendored graphviz.
+if (pip-grep -s requirements.txt Graphviz graphviz pygraphviz &> /dev/null) then
+
+  echo "-----> Noticed Graphviz. Bootstrapping graphviz."
+  mkdir -p .heroku/vendor
+  # Download and extract into target vendor directory.
+  curl $VENDORED_GRAPHVIZ -s | tar zxv -C .heroku/vendor &> /dev/null
+
+  export LIBRARY_PATH=${LIBRARY_PATH}:.heroku/vendor/lib
+  export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:.heroku/vendor/lib
+fi
+
+bpwatch stop graphviz_install

--- a/bin/steps/graphviz
+++ b/bin/steps/graphviz
@@ -29,6 +29,7 @@ if (pip-grep -s requirements.txt Graphviz graphviz pygraphviz &> /dev/null) then
 
   export LIBRARY_PATH=${LIBRARY_PATH}:.heroku/vendor/lib
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:.heroku/vendor/lib
+  export PATH=${PATH}:.heroku/vendor/bin
 fi
 
 bpwatch stop graphviz_install


### PR DESCRIPTION
* Certain Python libraries depend on Graphviz libraries and binaries in the runtime environment, I've templated off of similar binary package dependencies in this build pack to accommodate that requirement.

* I've already deployed a webapp utilizing this functionality, so it has therefor been tested. [Simple PyGrapviz Webapp](http://explainvizpy.cfapps.io)

* I am covered under a Corporate CLA
