### PR TITLE
Default Python 2.7.12, Pip 8.1.2, Setuptools 24.0.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -53,11 +53,11 @@ function bpwatch() {
 VIRTUALENV_LOC=".heroku/venv"
 LEGACY_TRIGGER="lib/python2.7"
 
-DEFAULT_PYTHON_VERSION="python-2.7.11"
+DEFAULT_PYTHON_VERSION="python-2.7.12"
 DEFAULT_PYTHON_STACK="cedar-14"
 PYTHON_EXE="/app/.heroku/python/bin/python"
-PIP_VERSION="8.1.1"
-SETUPTOOLS_VERSION="20.4"
+PIP_VERSION="8.1.2"
+SETUPTOOLS_VERSION="23.1.0"
 
 # Common Problem Warnings
 export WARNINGS_LOG=$(mktemp)

--- a/bin/compile
+++ b/bin/compile
@@ -57,7 +57,7 @@ DEFAULT_PYTHON_VERSION="python-2.7.12"
 DEFAULT_PYTHON_STACK="cedar-14"
 PYTHON_EXE="/app/.heroku/python/bin/python"
 PIP_VERSION="8.1.2"
-SETUPTOOLS_VERSION="23.1.0"
+SETUPTOOLS_VERSION="24.0.1"
 
 # Common Problem Warnings
 export WARNINGS_LOG=$(mktemp)


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

This suppresses warnings in deployment logs: `You are using pip version 8.1.1, however version 8.1.2 is available.`

These changes have already been made [upstream](https://github.com/heroku/heroku-buildpack-python/blob/master/bin/compile#L34-L38).

* An explanation of the use cases your change solves

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

