### PR TITLE
Use symlinks to save space during staging

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -68,7 +68,7 @@ $ROOT_DIR/compile-extensions/bin/check_stack_support
 # Move the ROOT_DIR contents to tmp and point ROOT_DIR to the new root
 TMP_ROOT=/tmp/buildpack
 rm -rf $TMP_ROOT
-cp -r $ROOT_DIR $TMP_ROOT
+cp -rs $ROOT_DIR $TMP_ROOT
 ROOT_DIR=$TMP_ROOT
 cd $ROOT_DIR
 
@@ -159,7 +159,7 @@ mkdir -p $CACHE_DIR
 # Restore old artifacts from the cache.
 mkdir -p .cloudfoundry
 
-cp -R $CACHE_DIR/.cloudfoundry/python .cloudfoundry/ &> /dev/null || true
+cp -Rl $CACHE_DIR/.cloudfoundry/python .cloudfoundry/ &> /dev/null || true
 cp -R $CACHE_DIR/.cloudfoundry/python-stack .cloudfoundry/ &> /dev/null || true
 cp -R $CACHE_DIR/.cloudfoundry/python-version .cloudfoundry/ &> /dev/null || true
 cp -R $CACHE_DIR/.cloudfoundry/vendor .cloudfoundry/ &> /dev/null || true
@@ -243,7 +243,7 @@ rm -rf $CACHE_DIR/.cloudfoundry/vendor
 rm -rf $CACHE_DIR/.cloudfoundry/src
 
 mkdir -p $CACHE_DIR/.cloudfoundry
-cp -R .cloudfoundry/python $CACHE_DIR/.cloudfoundry/
+cp -Rl .cloudfoundry/python $CACHE_DIR/.cloudfoundry/
 cp -R .cloudfoundry/python-version $CACHE_DIR/.cloudfoundry/
 cp -R .cloudfoundry/python-stack $CACHE_DIR/.cloudfoundry/ &> /dev/null || true
 cp -R .cloudfoundry/vendor $CACHE_DIR/.cloudfoundry/ &> /dev/null || true


### PR DESCRIPTION
Fixes #71

* Use symlinks between buildpack folders and app-cache directories.

* The buildpack uses less disk space during staging, allowing larger applications to deploy under the current 4G disk limit
