### PR TITLE
Deprecation warning for AppDynamics support

### DIFF
--- a/src/python/hooks/appdynamics.go
+++ b/src/python/hooks/appdynamics.go
@@ -217,9 +217,13 @@ func (h AppdynamicsHook) BeforeCompile(stager *libbuildpack.Stager) error {
 func init() {
 	logger := libbuildpack.NewLogger(os.Stdout)
 	command := &libbuildpack.Command{}
-
-	libbuildpack.AddHook(AppdynamicsHook{
-		Log:     logger,
-		Command: command,
-	})
+	if os.Getenv("APPD_AGENT") == "" {
+		logger.Warning("[DEPRECATION WARNING]: ")
+		logger.Warning("Please use AppDynamics extension buildpack for Python Application instrumentation")
+		logger.Warning("for more details: https://docs.pivotal.io/partners/appdynamics/multibuildpack.html")
+		libbuildpack.AddHook(AppdynamicsHook{
+			Log:     logger,
+			Command: command,
+		})
+	}
 }

--- a/src/python/hooks/appdynamics.go
+++ b/src/python/hooks/appdynamics.go
@@ -144,6 +144,15 @@ func (h AppdynamicsHook) CreateAppDynamicsEnv(stager *libbuildpack.Stager, envir
 }
 
 func (h AppdynamicsHook) BeforeCompile(stager *libbuildpack.Stager) error {
+	if os.Getenv("APPD_AGENT") != "" {
+		// APPD_AGENT is set => multibuildpack is used to configure appdynamics agent. Do nothing.
+		return nil
+	}
+
+	h.Log.Warning("[DEPRECATION WARNING]:")
+	h.Log.Warning("Please use AppDynamics extension buildpack for Python Application instrumentation")
+	h.Log.Warning("for more details: https://docs.pivotal.io/partners/appdynamics/multibuildpack.html")
+
 	vcapServices := os.Getenv("VCAP_SERVICES")
 	services := make(map[string][]Plan)
 
@@ -217,13 +226,8 @@ func (h AppdynamicsHook) BeforeCompile(stager *libbuildpack.Stager) error {
 func init() {
 	logger := libbuildpack.NewLogger(os.Stdout)
 	command := &libbuildpack.Command{}
-	if os.Getenv("APPD_AGENT") == "" {
-		logger.Warning("[DEPRECATION WARNING]: ")
-		logger.Warning("Please use AppDynamics extension buildpack for Python Application instrumentation")
-		logger.Warning("for more details: https://docs.pivotal.io/partners/appdynamics/multibuildpack.html")
-		libbuildpack.AddHook(AppdynamicsHook{
-			Log:     logger,
-			Command: command,
-		})
-	}
+	libbuildpack.AddHook(AppdynamicsHook{
+		Log:     logger,
+		Command: command,
+	})
 }


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

So far, appdynamics agent configuration has been carried out via hooks mechanism present in the builldpack. Moving forward, we would like to do so using multi buildpack approach. We have already move configuration logic to our supply buildpack (appdbuildpack) which is released as a part of our Service Broker Tile. 

But for some time we would like to issue a deprecation warning till all our users move to using multi buildpack approach. 

During this time users can still use cloudfoundry buildpacks to configure appdynamics agents and instrument applications. 

Users who would like to move multi buildpack approach can set APPD_AGENT env variable which will route the configuration logic supply buildpack and omits standard buildpack. 


* An explanation of the use cases your change solves

* [x ] I have viewed signed and have submitted the Contributor License Agreement

* [ x] I have made this pull request to the `develop` branch

* [] I have added an integration test
