### PR TITLE
update pydistutils.cfg to support allow_hosts

### DIFF
--- a/src/python/supply/supply_suite_test.go
+++ b/src/python/supply/supply_suite_test.go
@@ -4,10 +4,45 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"bufio"
+	"regexp"
+	"strings"
 	"testing"
 )
 
 func TestSupply(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Supply Suite")
+}
+
+// This will only parse [easy_install] section and return map
+func ParsePydistutils(contents string) map[string][]string {
+	configMap := make(map[string][]string)
+	scanner := bufio.NewScanner(strings.NewReader(contents))
+	var isEasyInstall = false
+	var currentKey = ""
+
+	// regular expression for `key = value`.
+	kv := regexp.MustCompile(`^([^=\n]+)=([^\n]*)`)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line[0] == '[' {
+			if strings.Compare("[easy_install]", line) == 0 {
+				isEasyInstall = true
+			} else {
+				isEasyInstall = false
+			}
+		} else if isEasyInstall {
+			m := kv.FindStringSubmatch(line)
+			if len(m) > 0 {
+				currentKey = strings.Trim(m[len(m)-2], " ")
+				value := strings.Trim(m[len(m)-1], "\r\n\t ")
+				configMap[currentKey] = []string{value}
+			} else {
+				value := strings.Trim(line, "\r\n\t ")
+				configMap[currentKey] = append(configMap[currentKey], value)
+			}
+		}
+	}
+	return configMap
 }


### PR DESCRIPTION
Based on requirements format, hyphen is missing in `-index-url` and `-extra-index-url`. Also, `--trusted-host` also needs when use internal host. 
`--trusted-host` is multiple args, but `find_links` is comma separated string.


Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
