### PR TITLE
Respect file URL when generating requirements.txt from Pipfile.lock

### DIFF
--- a/src/python/supply/supply.go
+++ b/src/python/supply/supply.go
@@ -421,6 +421,8 @@ func pipfileToRequirements(lockFilePath string) (string, error) {
 			}
 		} `json:"_meta"`
 		Default map[string]struct {
+			Extras  string
+			File    string
 			Version string
 		}
 	}
@@ -442,7 +444,15 @@ func pipfileToRequirements(lockFilePath string) (string, error) {
 	}
 
 	for pkg, obj := range lockFile.Default {
-		fmt.Fprintf(buf, "%s%s\n", pkg, obj.Version)
+		if obj.File != "" {
+			if obj.Extras != "" {
+				fmt.Fprintf(buf, "%s#egg=%s[%s]\n", obj.File, pkg, obj.Extras)
+			} else {
+				fmt.Fprintf(buf, "%s#egg=%s\n", obj.File, pkg)
+			}
+		} else {
+			fmt.Fprintf(buf, "%s%s\n", pkg, obj.Version)
+		}
 	}
 
 	return buf.String(), nil

--- a/src/python/supply/supply_test.go
+++ b/src/python/supply/supply_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Supply", func() {
 
 		Context("when Pipfile.lock exists but requirements.txt does not exist", func() {
 			BeforeEach(func() {
-				const lockFileContnet string = `{"_meta":{"sources":[{"url":"https://pypi.org/simple"}]},"default":{"test":{"version":"==1.2.3"}}}`
+				const lockFileContnet string = `{"_meta":{"sources":[{"url":"https://pypi.org/simple"}]},"default":{"test":{"version":"==1.2.3"},"testfile":{"file":"https://example.org/testfile.tgz"},"testfile2":{"file":"https://example.org/testfile2.tgz","extras":"develop"}}}`
 				Expect(ioutil.WriteFile(filepath.Join(buildDir, "Pipfile"), []byte("some content"), 0644)).To(Succeed())
 				Expect(ioutil.WriteFile(filepath.Join(buildDir, "Pipfile.lock"), []byte(lockFileContnet), 0644)).To(Succeed())
 			})
@@ -207,6 +207,8 @@ var _ = Describe("Supply", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(requirementsContents).To(ContainSubstring("-i https://pypi.org/simple"))
 				Expect(requirementsContents).To(ContainSubstring("test==1.2.3"))
+				Expect(requirementsContents).To(ContainSubstring("https://example.org/testfile.tgz#egg=testfile"))
+				Expect(requirementsContents).To(ContainSubstring("https://example.org/testfile2.tgz#egg=testfile2[develop]"))
 			})
 		})
 


### PR DESCRIPTION
When file URLs are provided in Pipfile.lock (e.g. https://github.com/pypa/pipenv/blob/d618cad3d14eb0b8fe1a65d05632b8bf27281c09/tests/unit/test_utils.py#L56-L62), use them to generate requirements.txt.


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
