### PR TITLE
Support independent pip version

### DIFF
--- a/src/python/integration/deploy_a_python_app_test.go
+++ b/src/python/integration/deploy_a_python_app_test.go
@@ -278,4 +278,33 @@ var _ = Describe("CF Python Buildpack", func() {
 		Expect(app.GetBody("/")).To(ContainSubstring("Hello, World!"))
 		Eventually(app.Stdout.String).Should(MatchRegexp(`\[APP/PROC/WEB/0\] .* "GET / HTTP/1.1"`))
 	})
+
+	Context("specifying pip version", func() {
+		Context("default", func() {
+			BeforeEach(func() {
+				app = cutlass.New(Fixtures("flask"))
+				app.SetEnv("BP_PIP_VERSION", "")
+			})
+
+			It("uses python's pip module", func() {
+				PushAppAndConfirm(app)
+				Expect(app.GetBody("/")).To(ContainSubstring("Hello, World!"))
+				Expect(app.Stdout.String()).To(ContainSubstring("Using python's pip module"))
+			})
+		})
+
+		Context("latest", func() {
+			BeforeEach(func() {
+				app = cutlass.New(Fixtures("flask"))
+				app.SetEnv("BP_PIP_VERSION", "latest")
+			})
+
+			It("uses latest from manifest", func() {
+				PushAppAndConfirm(app)
+				Expect(app.GetBody("/")).To(ContainSubstring("Hello, World!"))
+				Expect(app.Stdout.String()).To(ContainSubstring("Installing pip"))
+				Expect(app.Stdout.String()).To(MatchRegexp(`Successfully installed pip-\d+.\d+.\d+`))
+			})
+		})
+	})
 })


### PR DESCRIPTION
Adds support for installing a version of pip that is independent of python, to be used for this buildpack's build logic. This PR adds only a single pip version to the manifest, which is selectable by setting `$BP_PIP_VERSION=latest` (env var named as such for easier potential extensibility -- e.g. adding more versions of pip to the manifest, selectable by version number). If this env var is empty/unset, nothing will be installed and python's own pip module will be used for the build.

Resolves #172
Resolves #171 (since the added version of pip contains `wheel` and `setuptools`)

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [x] I have added an integration test
