### PR TITLE
Remove the usage of pip-pop library

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -53,14 +53,6 @@ dependencies:
   - cflinuxfs3
   source: https://files.pythonhosted.org/packages/88/d9/761f0b1e0551a3559afe4d34bd9bf68fc8de3292363b3775dda39b62ce84/pip-22.0.3.tar.gz
   source_sha256: f29d589df8c8ab99c060e68ad294c4a9ed896624f6368c5349d70aa581b333d0
-- name: pip-pop
-  version: 0.1.5
-  cf_stacks:
-  - cflinuxfs3
-  uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/pip-pop/pip-pop-0.1.5-b32efe86.tar.gz
-  sha256: b32efe865fc6d956e3345690215bc92a7038acf728db228243097b254403048f
-  source: https://github.com/cloudfoundry/pip-pop/archive/v0.1.5.tar.gz
-  source_sha256: 879221acbf123fb24e4a91b3d02e400031f89799bb70316fd97f36d2307a8230
 - name: pipenv
   version: 2022.1.8
   uri: https://buildpacks.cloudfoundry.org/dependencies/pipenv/pipenv_2022.1.8_linux_noarch_cflinuxfs3_119108d6.tgz

--- a/src/python/finalize/cli/main.go
+++ b/src/python/finalize/cli/main.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"github.com/cloudfoundry/python-buildpack/src/python/finalize"
-	_ "github.com/cloudfoundry/python-buildpack/src/python/hooks"
-	"github.com/cloudfoundry/python-buildpack/src/python/pyfinder"
-	"github.com/cloudfoundry/python-buildpack/src/python/requirements"
 	"io"
 	"io/ioutil"
 	"os"
 	"time"
+
+	"github.com/cloudfoundry/python-buildpack/src/python/finalize"
+	_ "github.com/cloudfoundry/python-buildpack/src/python/hooks"
+	"github.com/cloudfoundry/python-buildpack/src/python/pyfinder"
+	"github.com/cloudfoundry/python-buildpack/src/python/requirements"
 
 	"github.com/cloudfoundry/libbuildpack"
 )

--- a/src/python/finalize/cli/main.go
+++ b/src/python/finalize/cli/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"io"
-	"io/ioutil"
-	"os"
 	"github.com/cloudfoundry/python-buildpack/src/python/finalize"
 	_ "github.com/cloudfoundry/python-buildpack/src/python/hooks"
 	"github.com/cloudfoundry/python-buildpack/src/python/pyfinder"
+	"github.com/cloudfoundry/python-buildpack/src/python/requirements"
+	"io"
+	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/cloudfoundry/libbuildpack"
@@ -55,6 +56,7 @@ func main() {
 		Logfile:        logfile,
 		Command:        &libbuildpack.Command{},
 		ManagePyFinder: pyfinder.ManagePyFinder{},
+		Requirements:   requirements.Reqs{},
 	}
 
 	if err := finalize.Run(&f); err != nil {

--- a/src/python/finalize/finalize.go
+++ b/src/python/finalize/finalize.go
@@ -34,6 +34,11 @@ type ManagePyFinder interface {
 	FindManagePy(dir string) (string, error)
 }
 
+type Reqs interface {
+	FindAnyPackage(buildDir string, searchedPackages ...string) (bool, error)
+	FindStalePackages(oldRequirementsPath, newRequirementsPath string, excludedPackages ...string) ([]string, error)
+}
+
 type Finalizer struct {
 	Stager         Stager
 	Log            *libbuildpack.Logger
@@ -41,6 +46,7 @@ type Finalizer struct {
 	Manifest       Manifest
 	Command        Command
 	ManagePyFinder ManagePyFinder
+	Requirements   Reqs
 }
 
 func Run(f *Finalizer) error {
@@ -67,19 +73,22 @@ func (f *Finalizer) HandleCollectstatic() error {
 	if len(os.Getenv("DISABLE_COLLECTSTATIC")) > 0 {
 		return nil
 	}
-	if err := f.Command.Execute(f.Stager.BuildDir(), os.Stdout, os.Stderr, "pip-grep", "-s", "requirements.txt", "django", "Django"); err != nil {
-		return nil
-	}
 
-	managePyPath, err := f.ManagePyFinder.FindManagePy(f.Stager.BuildDir())
+	exists, err := f.Requirements.FindAnyPackage(f.Stager.BuildDir(), "django", "Django")
 	if err != nil {
 		return err
 	}
 
-	f.Log.Info("Running python %s collectstatic --noinput --traceback", managePyPath)
-	output := new(bytes.Buffer)
-	if err = f.Command.Execute(f.Stager.BuildDir(), output, text.NewIndentWriter(os.Stderr, []byte("       ")), "python", managePyPath, "collectstatic", "--noinput", "--traceback"); err != nil {
-		f.Log.Error(fmt.Sprintf(` !     Error while running '$ python %s collectstatic --noinput'.
+	if exists {
+		managePyPath, err := f.ManagePyFinder.FindManagePy(f.Stager.BuildDir())
+		if err != nil {
+			return err
+		}
+
+		f.Log.Info("Running python %s collectstatic --noinput --traceback", managePyPath)
+		output := new(bytes.Buffer)
+		if err = f.Command.Execute(f.Stager.BuildDir(), output, text.NewIndentWriter(os.Stderr, []byte("       ")), "python", managePyPath, "collectstatic", "--noinput", "--traceback"); err != nil {
+			f.Log.Error(fmt.Sprintf(` !     Error while running '$ python %s collectstatic --noinput'.
        See traceback above for details.
 
        You may need to update application code to resolve this error.
@@ -88,10 +97,11 @@ func (f *Finalizer) HandleCollectstatic() error {
           $ cf set-env <app> DISABLE_COLLECTSTATIC 1
 
        https://devcenter.heroku.com/articles/django-assets`, managePyPath))
-		return err
-	}
+			return err
+		}
 
-	writeFilteredCollectstaticOutput(output)
+		writeFilteredCollectstaticOutput(output)
+	}
 
 	return nil
 }

--- a/src/python/finalize/finalize_test.go
+++ b/src/python/finalize/finalize_test.go
@@ -33,6 +33,7 @@ var _ = Describe("Finalize", func() {
 		mockManifest       *MockManifest
 		mockCommand        *MockCommand
 		mockManagePyFinder *MockManagePyFinder
+		mockRequirements   *MockReqs
 	)
 
 	BeforeEach(func() {
@@ -53,6 +54,7 @@ var _ = Describe("Finalize", func() {
 		mockManifest = NewMockManifest(mockCtrl)
 		mockCommand = NewMockCommand(mockCtrl)
 		mockManagePyFinder = NewMockManagePyFinder(mockCtrl)
+		mockRequirements = NewMockReqs(mockCtrl)
 
 		args := []string{buildDir, "", depsDir, depsIdx}
 		stager := libbuildpack.NewStager(args, logger, &libbuildpack.Manifest{})
@@ -63,6 +65,7 @@ var _ = Describe("Finalize", func() {
 			Log:            logger,
 			Command:        mockCommand,
 			ManagePyFinder: mockManagePyFinder,
+			Requirements:   mockRequirements,
 		}
 	})
 
@@ -93,7 +96,7 @@ var _ = Describe("Finalize", func() {
 			})
 			Context("app uses Django", func() {
 				BeforeEach(func() {
-					mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "pip-grep", "-s", "requirements.txt", "django", "Django").Return(nil)
+					mockRequirements.EXPECT().FindAnyPackage(buildDir, "django", "Django").Return(true, nil)
 					mockManagePyFinder.EXPECT().FindManagePy(buildDir).Return("/foo/bar/manage.py", nil)
 				})
 
@@ -118,7 +121,7 @@ var _ = Describe("Finalize", func() {
 
 			Context("app does not use Django", func() {
 				BeforeEach(func() {
-					mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "pip-grep", "-s", "requirements.txt", "django", "Django").Return(fmt.Errorf("Not found"))
+					mockRequirements.EXPECT().FindAnyPackage(buildDir, "django", "Django").Return(false, nil)
 				})
 
 				It("does not run anything", func() {

--- a/src/python/finalize/mocks_test.go
+++ b/src/python/finalize/mocks_test.go
@@ -226,3 +226,66 @@ func (mr *MockManagePyFinderMockRecorder) FindManagePy(dir interface{}) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindManagePy", reflect.TypeOf((*MockManagePyFinder)(nil).FindManagePy), dir)
 }
+
+// MockReqs is a mock of Reqs interface.
+type MockReqs struct {
+	ctrl     *gomock.Controller
+	recorder *MockReqsMockRecorder
+}
+
+// MockReqsMockRecorder is the mock recorder for MockReqs.
+type MockReqsMockRecorder struct {
+	mock *MockReqs
+}
+
+// NewMockReqs creates a new mock instance.
+func NewMockReqs(ctrl *gomock.Controller) *MockReqs {
+	mock := &MockReqs{ctrl: ctrl}
+	mock.recorder = &MockReqsMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockReqs) EXPECT() *MockReqsMockRecorder {
+	return m.recorder
+}
+
+// FindAnyPackage mocks base method.
+func (m *MockReqs) FindAnyPackage(buildDir string, searchedPackages ...string) (bool, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{buildDir}
+	for _, a := range searchedPackages {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FindAnyPackage", varargs...)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindAnyPackage indicates an expected call of FindAnyPackage.
+func (mr *MockReqsMockRecorder) FindAnyPackage(buildDir interface{}, searchedPackages ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{buildDir}, searchedPackages...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAnyPackage", reflect.TypeOf((*MockReqs)(nil).FindAnyPackage), varargs...)
+}
+
+// FindStalePackages mocks base method.
+func (m *MockReqs) FindStalePackages(oldRequirementsPath, newRequirementsPath string, excludedPackages ...string) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{oldRequirementsPath, newRequirementsPath}
+	for _, a := range excludedPackages {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FindStalePackages", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindStalePackages indicates an expected call of FindStalePackages.
+func (mr *MockReqsMockRecorder) FindStalePackages(oldRequirementsPath, newRequirementsPath interface{}, excludedPackages ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{oldRequirementsPath, newRequirementsPath}, excludedPackages...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindStalePackages", reflect.TypeOf((*MockReqs)(nil).FindStalePackages), varargs...)
+}

--- a/src/python/requirements/requirements.go
+++ b/src/python/requirements/requirements.go
@@ -1,0 +1,91 @@
+package requirements
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type Reqs struct{}
+
+func (m Reqs) FindAnyPackage(buildDir string, searchedPackages ...string) (bool, error) {
+	reqPackages, err := parseRequirementsWithoutVersion(filepath.Join(buildDir, "requirements.txt"))
+	if err != nil {
+		return false, err
+	}
+
+	for _, searchedPackage := range searchedPackages {
+		if containsPackage(reqPackages, searchedPackage) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (m Reqs) FindStalePackages(oldRequirementsPath, newRequirementsPath string, excludedPackages ...string) ([]string, error) {
+	var stalePackages []string
+
+	oldPkgs, err := parseRequirements(oldRequirementsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	newPkgs, err := parseRequirements(newRequirementsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, oldPkg := range oldPkgs {
+		if !containsPackage(newPkgs, oldPkg) && !packageIsExcluded(excludedPackages, oldPkg) {
+			stalePackages = append(stalePackages, oldPkg)
+		}
+	}
+
+	return stalePackages, nil
+}
+
+func containsPackage(packages []string, searchedPackage string) bool {
+	for _, pkg := range packages {
+		if pkg == searchedPackage {
+			return true
+		}
+	}
+	return false
+}
+
+func packageIsExcluded(excludedPackages []string, packageFullName string) bool {
+	regex := regexp.MustCompile(`(?m)^[\w\-\w\[\]]+`)
+
+	packageWithoutVersion := regex.FindString(packageFullName)
+
+	for _, excludedPackage := range excludedPackages {
+		if packageWithoutVersion == excludedPackage {
+			return true
+		}
+	}
+
+	return false
+}
+
+func parseRequirements(requirementsPath string) ([]string, error) {
+	content, err := ioutil.ReadFile(requirementsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(string(content), "\n"), nil
+	//// TODO: Add support for nested requirements.txt files
+}
+
+func parseRequirementsWithoutVersion(requirementsPath string) ([]string, error) {
+	content, err := ioutil.ReadFile(requirementsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	//// TODO: Add support for nested requirements.txt files
+	regex := regexp.MustCompile(`(?m)^[\w\-\w\[\]]+`)
+	return regex.FindAllString(string(content), -1), nil
+}

--- a/src/python/requirements/requirements.go
+++ b/src/python/requirements/requirements.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const requirementsParserRegex = `(?m)^[\w\-\w\[\]]+`
+
 type Reqs struct{}
 
 func (m Reqs) FindAnyPackage(buildDir string, searchedPackages ...string) (bool, error) {
@@ -56,7 +58,8 @@ func containsPackage(packages []string, searchedPackage string) bool {
 }
 
 func packageIsExcluded(excludedPackages []string, packageFullName string) bool {
-	regex := regexp.MustCompile(`(?m)^[\w\-\w\[\]]+`)
+
+	regex := regexp.MustCompile(requirementsParserRegex)
 
 	packageWithoutVersion := regex.FindString(packageFullName)
 

--- a/src/python/requirements/requirements_suite_test.go
+++ b/src/python/requirements/requirements_suite_test.go
@@ -1,0 +1,13 @@
+package requirements_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRequirements(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Reqs Suite")
+}

--- a/src/python/requirements/requirements_test.go
+++ b/src/python/requirements/requirements_test.go
@@ -1,11 +1,12 @@
 package requirements
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Reqs", func() {

--- a/src/python/requirements/requirements_test.go
+++ b/src/python/requirements/requirements_test.go
@@ -1,0 +1,123 @@
+package requirements
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+var _ = Describe("Reqs", func() {
+	var (
+		tempDir string
+		req     Reqs
+		err     error
+	)
+
+	BeforeEach(func() {
+		tempDir, err = ioutil.TempDir("", "requirements")
+		Expect(err).NotTo(HaveOccurred())
+		req = Reqs{}
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tempDir)).To(Succeed())
+	})
+
+	Describe("FindAnyPackage", func() {
+		Context("succeed", func() {
+			BeforeEach(func() {
+				Expect(ioutil.WriteFile(filepath.Join(tempDir, "requirements.txt"), []byte(`package0
+package2>=2.0.0
+package3!=3.0.0
+package4~=4.0.0
+package6[test]==6.0.0
+`), 0644)).To(Succeed())
+			})
+
+			Context("package is not in requirements.txt file", func() {
+				It("returns false and nil error", func() {
+					exists, err := req.FindAnyPackage(tempDir, "package1")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(exists).To(BeFalse())
+
+					exists, err = req.FindAnyPackage(tempDir, "package5")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(exists).To(BeFalse())
+				})
+			})
+
+			Context("package is in requirements.txt file", func() {
+				It("returns true and nil error", func() {
+					exists, err := req.FindAnyPackage(tempDir, "package2")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(exists).To(BeTrue())
+
+					exists, err = req.FindAnyPackage(tempDir, "package6[test]")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(exists).To(BeTrue())
+				})
+			})
+		})
+
+		Context("failure", func() {
+			Context("error opening requirements.txt file", func() {
+				It("returns the error", func() {
+					_, err := req.FindAnyPackage("invalid-directory", "package0")
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+	})
+
+	Describe("FindStalePackages", func() {
+		Context("succeed", func() {
+			BeforeEach(func() {
+				Expect(ioutil.WriteFile(filepath.Join(tempDir, "req-old.txt"), []byte(`package0
+package1==2.0.0
+package2
+package3==3.0.0
+package4
+package5!=4.0.0
+`), 0644)).To(Succeed())
+				Expect(ioutil.WriteFile(filepath.Join(tempDir, "req-new.txt"), []byte(`package0
+package1==2.0.0
+`), 0644)).To(Succeed())
+			})
+
+			It("returns stale packages", func() {
+				stale, err := req.FindStalePackages(filepath.Join(tempDir, "req-old.txt"), filepath.Join(tempDir, "req-new.txt"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stale).To(ConsistOf("package2", "package3==3.0.0", "package4", "package5!=4.0.0"))
+			})
+
+			It("returns stale packages that are not in the excluded list", func() {
+				stale, err := req.FindStalePackages(filepath.Join(tempDir, "req-old.txt"), filepath.Join(tempDir, "req-new.txt"),
+					"package2", "package3")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stale).To(ConsistOf("package4", "package5!=4.0.0"))
+			})
+		})
+
+		Context("failure", func() {
+			BeforeEach(func() {
+				Expect(ioutil.WriteFile(filepath.Join(tempDir, "valid-req.txt"), []byte(`package0`), 0644)).To(Succeed())
+			})
+
+			Context("error opening old requirements file", func() {
+				It("returns the error", func() {
+					_, err := req.FindStalePackages(filepath.Join(tempDir, "missing.txt"), filepath.Join(tempDir, "valid-req.txt"))
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("error opening new requirements file", func() {
+				It("returns the error", func() {
+					_, err := req.FindStalePackages(filepath.Join(tempDir, "valid-req.txt"), filepath.Join(tempDir, "missing.txt"))
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+	})
+})

--- a/src/python/supply/cli/main.go
+++ b/src/python/supply/cli/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	_ "github.com/cloudfoundry/python-buildpack/src/python/hooks"
+	"github.com/cloudfoundry/python-buildpack/src/python/requirements"
+	"github.com/cloudfoundry/python-buildpack/src/python/supply"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	_ "github.com/cloudfoundry/python-buildpack/src/python/hooks"
-	"github.com/cloudfoundry/python-buildpack/src/python/supply"
 	"time"
 
 	"github.com/cloudfoundry/libbuildpack"
@@ -71,12 +72,13 @@ func main() {
 	}
 
 	s := supply.Supplier{
-		Logfile:   logfile,
-		Stager:    stager,
-		Manifest:  manifest,
-		Installer: installer,
-		Log:       logger,
-		Command:   &libbuildpack.Command{},
+		Logfile:      logfile,
+		Stager:       stager,
+		Manifest:     manifest,
+		Installer:    installer,
+		Log:          logger,
+		Command:      &libbuildpack.Command{},
+		Requirements: requirements.Reqs{},
 	}
 
 	err = supply.Run(&s)

--- a/src/python/supply/cli/main.go
+++ b/src/python/supply/cli/main.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	_ "github.com/cloudfoundry/python-buildpack/src/python/hooks"
-	"github.com/cloudfoundry/python-buildpack/src/python/requirements"
-	"github.com/cloudfoundry/python-buildpack/src/python/supply"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
+
+	_ "github.com/cloudfoundry/python-buildpack/src/python/hooks"
+	"github.com/cloudfoundry/python-buildpack/src/python/requirements"
+	"github.com/cloudfoundry/python-buildpack/src/python/supply"
 
 	"github.com/cloudfoundry/libbuildpack"
 )

--- a/src/python/supply/mocks_test.go
+++ b/src/python/supply/mocks_test.go
@@ -327,3 +327,66 @@ func (mr *MockCommandMockRecorder) RunWithOutput(cmd interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunWithOutput", reflect.TypeOf((*MockCommand)(nil).RunWithOutput), cmd)
 }
+
+// MockReqs is a mock of Reqs interface.
+type MockReqs struct {
+	ctrl     *gomock.Controller
+	recorder *MockReqsMockRecorder
+}
+
+// MockReqsMockRecorder is the mock recorder for MockReqs.
+type MockReqsMockRecorder struct {
+	mock *MockReqs
+}
+
+// NewMockReqs creates a new mock instance.
+func NewMockReqs(ctrl *gomock.Controller) *MockReqs {
+	mock := &MockReqs{ctrl: ctrl}
+	mock.recorder = &MockReqsMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockReqs) EXPECT() *MockReqsMockRecorder {
+	return m.recorder
+}
+
+// FindAnyPackage mocks base method.
+func (m *MockReqs) FindAnyPackage(buildDir string, searchedPackages ...string) (bool, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{buildDir}
+	for _, a := range searchedPackages {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FindAnyPackage", varargs...)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindAnyPackage indicates an expected call of FindAnyPackage.
+func (mr *MockReqsMockRecorder) FindAnyPackage(buildDir interface{}, searchedPackages ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{buildDir}, searchedPackages...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAnyPackage", reflect.TypeOf((*MockReqs)(nil).FindAnyPackage), varargs...)
+}
+
+// FindStalePackages mocks base method.
+func (m *MockReqs) FindStalePackages(oldRequirementsPath, newRequirementsPath string, excludedPackages ...string) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{oldRequirementsPath, newRequirementsPath}
+	for _, a := range excludedPackages {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FindStalePackages", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindStalePackages indicates an expected call of FindStalePackages.
+func (mr *MockReqsMockRecorder) FindStalePackages(oldRequirementsPath, newRequirementsPath interface{}, excludedPackages ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{oldRequirementsPath, newRequirementsPath}, excludedPackages...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindStalePackages", reflect.TypeOf((*MockReqs)(nil).FindStalePackages), varargs...)
+}

--- a/src/python/supply/supply.go
+++ b/src/python/supply/supply.go
@@ -484,11 +484,12 @@ func (s *Supplier) HandlePylibmc() error {
 		return err
 	}
 
-	if exists {
-		return s.installLibmemcache()
+	if !exists {
+
+		return nil
 	}
 
-	return nil
+	return s.installLibmemcache()
 }
 
 func (s *Supplier) installLibmemcache() error {
@@ -552,11 +553,12 @@ func (s *Supplier) HandleFfi() error {
 		return err
 	}
 
-	if exists {
-		return s.installFfi()
+	if !exists {
+
+		return nil
 	}
 
-	return nil
+	return s.installFfi()
 }
 
 func (s *Supplier) UninstallUnusedDependencies() error {

--- a/src/python/supply/supply.go
+++ b/src/python/supply/supply.go
@@ -50,6 +50,11 @@ type Command interface {
 	RunWithOutput(cmd *exec.Cmd) ([]byte, error)
 }
 
+type Reqs interface {
+	FindAnyPackage(buildDir string, searchedPackages ...string) (bool, error)
+	FindStalePackages(oldRequirementsPath, newRequirementsPath string, excludedPackages ...string) ([]string, error)
+}
+
 type Supplier struct {
 	PythonVersion          string
 	Manifest               Manifest
@@ -60,6 +65,7 @@ type Supplier struct {
 	Logfile                *os.File
 	HasNltkData            bool
 	removeRequirementsText bool
+	Requirements           Reqs
 }
 
 func Run(s *Supplier) error {
@@ -99,11 +105,6 @@ func RunPython(s *Supplier) error {
 
 	if err := s.InstallPip(); err != nil {
 		s.Log.Error("Could not install pip: %v", err)
-		return err
-	}
-
-	if err := s.InstallPipPop(); err != nil {
-		s.Log.Error("Could not install pip pop: %v", err)
 		return err
 	}
 
@@ -365,22 +366,6 @@ func (s *Supplier) InstallPip() error {
 	return s.Stager.LinkDirectoryInDepDir(filepath.Join(s.Stager.DepDir(), "python", "bin"), "bin")
 }
 
-func (s *Supplier) InstallPipPop() error {
-	tempPath := filepath.Join("/tmp", "pip-pop")
-	if err := s.Installer.InstallOnlyVersion("pip-pop", tempPath); err != nil {
-		return err
-	}
-
-	if err := s.runPipInstall("pip-pop", "--exists-action=w", "--no-index", fmt.Sprintf("--find-links=%s", tempPath)); err != nil {
-		return err
-	}
-
-	if err := s.Stager.LinkDirectoryInDepDir(filepath.Join(s.Stager.DepDir(), "python", "bin"), "bin"); err != nil {
-		return err
-	}
-	return nil
-}
-
 func (s *Supplier) InstallPipEnv() error {
 	requirementstxtExists, err := libbuildpack.FileExists(filepath.Join(s.Stager.BuildDir(), "requirements.txt"))
 	if err != nil {
@@ -494,21 +479,30 @@ func pipfileToRequirements(lockFilePath string) (string, error) {
 }
 
 func (s *Supplier) HandlePylibmc() error {
-	memcachedDir := filepath.Join(s.Stager.DepDir(), "libmemcache")
-
-	if err := s.Command.Execute(s.Stager.BuildDir(), ioutil.Discard, ioutil.Discard, "pip-grep", "-s", "requirements.txt", "pylibmc"); err == nil {
-		s.Log.BeginStep("Noticed pylibmc. Bootstrapping libmemcached.")
-		if err := s.Installer.InstallOnlyVersion("libmemcache", memcachedDir); err != nil {
-			return err
-		}
-		os.Setenv("LIBMEMCACHED", memcachedDir)
-		s.Stager.WriteEnvFile("LIBMEMCACHED", memcachedDir)
-		s.Stager.LinkDirectoryInDepDir(filepath.Join(memcachedDir, "lib"), "lib")
-		s.Stager.LinkDirectoryInDepDir(filepath.Join(memcachedDir, "lib", "sasl2"), "lib")
-		s.Stager.LinkDirectoryInDepDir(filepath.Join(memcachedDir, "lib", "pkgconfig"), "pkgconfig")
-		s.Stager.LinkDirectoryInDepDir(filepath.Join(memcachedDir, "include"), "include")
+	exists, err := s.Requirements.FindAnyPackage(s.Stager.BuildDir(), "pylibmc")
+	if err != nil {
+		return err
 	}
 
+	if exists {
+		return s.installLibmemcache()
+	}
+
+	return nil
+}
+
+func (s *Supplier) installLibmemcache() error {
+	memcachedDir := filepath.Join(s.Stager.DepDir(), "libmemcache")
+	s.Log.BeginStep("Noticed pylibmc. Bootstrapping libmemcached.")
+	if err := s.Installer.InstallOnlyVersion("libmemcache", memcachedDir); err != nil {
+		return err
+	}
+	os.Setenv("LIBMEMCACHED", memcachedDir)
+	s.Stager.WriteEnvFile("LIBMEMCACHED", memcachedDir)
+	s.Stager.LinkDirectoryInDepDir(filepath.Join(memcachedDir, "lib"), "lib")
+	s.Stager.LinkDirectoryInDepDir(filepath.Join(memcachedDir, "lib", "sasl2"), "lib")
+	s.Stager.LinkDirectoryInDepDir(filepath.Join(memcachedDir, "lib", "pkgconfig"), "pkgconfig")
+	s.Stager.LinkDirectoryInDepDir(filepath.Join(memcachedDir, "include"), "include")
 	return nil
 }
 
@@ -551,9 +545,17 @@ func (s *Supplier) installFfi() error {
 }
 
 func (s *Supplier) HandleFfi() error {
-	if err := s.Command.Execute(s.Stager.BuildDir(), ioutil.Discard, ioutil.Discard, "pip-grep", "-s", "requirements.txt", "pymysql", "argon2-cffi", "bcrypt", "cffi", "cryptography", "django[argon2]", "Django[argon2]", "django[bcrypt]", "Django[bcrypt]", "PyNaCl", "pyOpenSSL", "PyOpenSSL", "requests[security]", "misaka"); err == nil {
+	exists, err := s.Requirements.FindAnyPackage(s.Stager.BuildDir(),
+		"pymysql", "argon2-cffi", "bcrypt", "cffi", "cryptography", "django[argon2]", "Django[argon2]",
+		"django[bcrypt]", "Django[bcrypt]", "PyNaCl", "pyOpenSSL", "PyOpenSSL", "requests[security]", "misaka")
+	if err != nil {
+		return err
+	}
+
+	if exists {
 		return s.installFfi()
 	}
+
 	return nil
 }
 
@@ -567,26 +569,22 @@ func (s *Supplier) UninstallUnusedDependencies() error {
 		fileContents, _ := ioutil.ReadFile(filepath.Join(s.Stager.DepDir(), "python", "requirements-declared.txt"))
 		s.Log.Info("requirements-declared: %s", string(fileContents))
 
-		staleContents, err := s.Command.Output(
-			s.Stager.BuildDir(),
-			"pip-diff",
-			"--stale",
+		staleContents, err := s.Requirements.FindStalePackages(
 			filepath.Join(s.Stager.DepDir(), "python", "requirements-declared.txt"),
 			filepath.Join(s.Stager.BuildDir(), "requirements.txt"),
-			"--exclude",
-			"setuptools",
-			"pip",
-			"wheel",
-		)
+			"setuptools", "pip", "wheel")
+
 		if err != nil {
 			return err
 		}
 
-		if staleContents == "" {
+		if len(staleContents) == 0 {
 			return nil
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(s.Stager.DepDir(), "python", "requirements-stale.txt"), []byte(staleContents), 0644); err != nil {
+		staleContentString := strings.Join(staleContents[:], "\n")
+
+		if err := ioutil.WriteFile(filepath.Join(s.Stager.DepDir(), "python", "requirements-stale.txt"), []byte(staleContentString), 0644); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
# Context
The pip-pop library presents some problems with `Python versions > 3.6` because it is a very old library and does not receive any updates.

# Proposed Solution
Both functionalities of the library (`pip-grep` and `pip-diff`) were recreated through new functions in go.
