### PR TITLE
Add Debug logging for collectstatic

### DIFF
--- a/src/python/finalize/finalize.go
+++ b/src/python/finalize/finalize.go
@@ -72,20 +72,24 @@ func Run(f *Finalizer) error {
 
 func (f *Finalizer) HandleCollectstatic() error {
 	if len(os.Getenv("DISABLE_COLLECTSTATIC")) > 0 {
+        f.Log.Debug("DISABLE_COLLECTSTATIC > 0, skipping collectstatic")
 		return nil
 	}
 
 	exists, err := f.Requirements.FindAnyPackage(f.Stager.BuildDir(), "django", "Django")
 	if err != nil {
+        f.Log.Debug("Error during FindAnyPackage, skipping collectstatic")
 		return err
 	}
 
 	if !exists {
+        f.Log.Debug("Django not in requirements, skipping collectstatic")
 		return nil
 	}
 
 	managePyPath, err := f.ManagePyFinder.FindManagePy(f.Stager.BuildDir())
 	if err != nil {
+        f.Log.Debug("Error finding manage.py, skipping collectstatic")
 		return err
 	}
 


### PR DESCRIPTION
The recent removal of the pip-pop library (see #468) is causing a number of my projects to no longer proper detect Django as a dependency. Debugging this is made hard by the lack of debug information on which of the 4 ways this is going wrong.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
