### PR TITLE
bumped libbuildpack-dynatrace to v1.5.0

### DIFF
--- a/fixtures/fake_dynatrace_api/fake_config.json
+++ b/fixtures/fake_dynatrace_api/fake_config.json
@@ -1,0 +1,11 @@
+{
+  "revision":1234567890,
+  "properties":
+  [
+    {
+      "section":"fakesection",
+      "key":"fakekey",
+      "value":"fakevalue"
+    }
+  ]
+}

--- a/fixtures/fake_dynatrace_api/install.sh
+++ b/fixtures/fake_dynatrace_api/install.sh
@@ -12,6 +12,7 @@ function main() {
   curl -s --fail "http://{{.URI}}/manifest.json" > "${dir}/dynatrace/oneagent/manifest.json"
   curl -s --fail "http://{{.URI}}/dynatrace-env.sh" > "${dir}/dynatrace/oneagent/dynatrace-env.sh"
   curl -s --fail "http://{{.URI}}/liboneagentproc.so" > "${dir}/dynatrace/oneagent/agent/lib64/liboneagentproc.so"
+  curl -s --fail "http://{{.URI}}/ruxitagentproc.conf" > "${dir}/dynatrace/oneagent/agent/conf/ruxitagentproc.conf"
 }
 
 main "${@}"

--- a/fixtures/fake_dynatrace_api/install.sh
+++ b/fixtures/fake_dynatrace_api/install.sh
@@ -8,6 +8,7 @@ function main() {
   echo "dir -> ${dir}"
 
   mkdir -p "${dir}/dynatrace/oneagent/agent/lib64"
+  mkdir -p "${dir}/dynatrace/oneagent/agent/conf"
 
   curl -s --fail "http://{{.URI}}/manifest.json" > "${dir}/dynatrace/oneagent/manifest.json"
   curl -s --fail "http://{{.URI}}/dynatrace-env.sh" > "${dir}/dynatrace/oneagent/dynatrace-env.sh"

--- a/fixtures/fake_dynatrace_api/main.go
+++ b/fixtures/fake_dynatrace_api/main.go
@@ -22,9 +22,20 @@ func main() {
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
-		switch req.URL.Path {
+		var withoutAgentPath bool
+		path := req.URL.Path
+
+		uri := application.ApplicationURIs[0]
+
+		if strings.HasPrefix(path, "/without-agent-path") {
+			uri = fmt.Sprintf("%s/without-agent-path", uri)
+			path = strings.TrimPrefix(path, "/without-agent-path")
+			withoutAgentPath = true
+		}
+
+		switch path {
 		case "/v1/deployment/installer/agent/unix/paas-sh/latest":
-			context := struct{ URI string }{URI: application.ApplicationURIs[0]}
+			context := struct{ URI string }{URI: uri}
 			t := template.Must(template.New("install.sh").ParseFiles("install.sh"))
 			err := t.Execute(w, context)
 			if err != nil {
@@ -33,7 +44,7 @@ func main() {
 				return
 			}
 
-		case "/manifest.json", "/dynatrace-env.sh", "/liboneagentproc.so":
+		case "/dynatrace-env.sh", "/liboneagentproc.so", "/ruxitagentproc.conf":
 			contents, err := ioutil.ReadFile(strings.TrimPrefix(req.URL.Path, "/"))
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
@@ -41,6 +52,42 @@ func main() {
 				return
 			}
 			w.Write(contents)
+
+		case "/manifest.json":
+			var payload map[string]interface{}
+			file, err := os.Open("manifest.json")
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(err.Error()))
+				return
+			}
+
+			err = json.NewDecoder(file).Decode(&payload)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(err.Error()))
+				return
+			}
+
+			if withoutAgentPath {
+				payload["technologies"] = map[string]interface{}{
+					"process": map[string]interface{}{
+						"linux-x86-64": []struct{}{},
+					},
+				}
+			}
+
+			json.NewEncoder(w).Encode(payload)
+
+		case "/v1/deployment/installer/agent/processmoduleconfig":
+			fakeConfig, err := ioutil.ReadFile("fake_config.json")
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(err.Error()))
+				return
+			}
+			w.Write(fakeConfig)
+
 
 		default:
 			w.WriteHeader(http.StatusNotFound)

--- a/fixtures/fake_dynatrace_api/ruxitagentproc.conf
+++ b/fixtures/fake_dynatrace_api/ruxitagentproc.conf
@@ -1,0 +1,3 @@
+# some comment
+[testsection]
+testkey testvalue

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cloudfoundry/python-buildpack
 
 require (
-	github.com/Dynatrace/libbuildpack-dynatrace v1.4.2
+	github.com/Dynatrace/libbuildpack-dynatrace v1.5.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20220329192604-c8ccbfd4cb8d
 	github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ code.cloudfoundry.org/lager v2.0.0+incompatible h1:WZwDKDB2PLd/oL+USK4b4aEjUymIe
 code.cloudfoundry.org/lager v2.0.0+incompatible/go.mod h1:O2sS7gKP3HM2iemG+EnwvyNQK7pTSC6Foi4QiMp9sSk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/Dynatrace/libbuildpack-dynatrace v1.4.2 h1:sGmRK5owrhyryDSDkX6PjxUTPj+RAxyD5W1rMLX3S1A=
-github.com/Dynatrace/libbuildpack-dynatrace v1.4.2/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
+github.com/Dynatrace/libbuildpack-dynatrace v1.5.0 h1:EZ2fSooBGd179dFbM673l1RE7zGfKuyVUujl/plWsnU=
+github.com/Dynatrace/libbuildpack-dynatrace v1.5.0/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/vendor/github.com/Dynatrace/libbuildpack-dynatrace/hook.go
+++ b/vendor/github.com/Dynatrace/libbuildpack-dynatrace/hook.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"regexp"
+	"bufio"
 
 	"github.com/cloudfoundry/libbuildpack"
 )
@@ -59,12 +61,14 @@ func NewHook(technologies ...string) libbuildpack.Hook {
 
 // AfterCompile downloads and installs the Dynatrace agent.
 func (h *Hook) AfterCompile(stager *libbuildpack.Stager) error {
+	// All other methods in this package are called  from here, which
+	// makes it the main entry-point.
+
 	var err error
 
 	h.Log.Debug("Checking for enabled dynatrace service...")
 
 	// Get credentials...
-
 	creds := h.getCredentials()
 	if creds == nil {
 		h.Log.Debug("Dynatrace service credentials not found!")
@@ -170,6 +174,18 @@ func (h *Hook) AfterCompile(stager *libbuildpack.Stager) error {
 
 	if _, err = f.WriteString(extra); err != nil {
 		return err
+	}
+
+	h.Log.Debug("Fetching updated OneAgent configuration from tenant... ")
+	configDir := filepath.Join(stager.BuildDir(), installDir)
+	if err := h.updateAgentConfig(*creds, configDir, lang, ver); err != nil {
+		if creds.SkipErrors {
+			h.Log.Warning("Error during agent config update, skipping it")
+			return nil
+		}
+		h.Log.Error("Error during agent config update: %s", err)
+		return err
+
 	}
 
 	h.Log.Info("Dynatrace OneAgent injection is set up.")
@@ -284,7 +300,7 @@ func (h *Hook) download(url, filePath string, buildPackVersion string, language 
 
 			if i == h.MaxDownloadRetries {
 				h.Log.Warning("Maximum number of retries attempted: %d", h.MaxDownloadRetries)
-				return fmt.Errorf("Download returned with status %s, error: %v", resp.Status, err)
+				return fmt.Errorf("download returned with status %s, error: %v", resp.Status, err)
 			}
 		} else {
 			h.Log.Debug("Download failed: %v", err)
@@ -372,4 +388,139 @@ func (h *Hook) findAgentPath(installDir string) (string, error) {
 	// Using fallback path if we don't find the 'primary' process agent.
 	h.Log.Warning("Agent path not found in manifest.json, using fallback!")
 	return fallbackPath, nil
+}
+
+// Downloads most recent agent config from configuration API of the tenant
+// and merges it with the local version the standalone installer package brings along.
+func (h* Hook) updateAgentConfig(creds credentials, installDir , buildPackLanguage, buildPackVersion string)  error {
+	// agentConfigProperty represents a line of raw data we get from the config api
+	type agentConfigProperty struct {
+		Section string
+		Key string
+		Value string
+	}
+
+	// Container type for agentConfigProperty.
+	// Used for easy unmarshalling.
+	type properties struct {
+		Properties []agentConfigProperty
+	}
+
+	// Fetch most recent OneAgent config from API, which we get back in JSON format
+	client := &http.Client{Timeout: 3 * time.Second}
+	agentConfigUrl := creds.APIURL + "/v1/deployment/installer/agent/processmoduleconfig"
+	req, _ := http.NewRequest("GET", agentConfigUrl, nil)
+	req.Header.Set("User-Agent", fmt.Sprintf("cf-%s-buildpack/%s", buildPackLanguage, buildPackVersion))
+	req.Header.Set("Authorization", fmt.Sprintf("Api-Token %s", creds.APIToken))
+	client.Do(req)
+	resp, err := client.Do(req)
+	if err != nil {
+		h.Log.Error("Failed to fetch OneAgent config from API: %s", err)
+		return err
+	}
+	h.Log.Debug("Successfully fetched OneAgent config from API")
+
+	var jsonConfig properties
+	json.NewDecoder(resp.Body).Decode(&jsonConfig)
+
+	configFromAPI := make(map[string]map[string]string)
+	for _, v := range jsonConfig.Properties {
+		// you gotta check if the required map is already there
+		// if not: initialize it with a nice make :-)
+		_, ok := configFromAPI[v.Section]
+		if !ok {
+			configFromAPI[v.Section] = make(map[string]string)
+		}
+		configFromAPI[v.Section][v.Key] = v.Value
+	}
+
+	// read data from ruxitagentproc.conf file
+	agentConfigPath := filepath.Join(installDir, "agent/conf/ruxitagentproc.conf")
+	agentConfigFile, err := os.Open(agentConfigPath)
+	if err != nil {
+		h.Log.Error("Failure while reading OneAgent config file %s: %s", agentConfigPath, err)
+		return err
+	}
+	h.Log.Debug("Successfully read OneAgent config from %s", agentConfigPath)
+	defer agentConfigFile.Close()
+
+	configFromAgent := make(map[string]map[string]string)
+	currentSection := ""
+	var configSection string
+	var sectionRegexp, _ = regexp.Compile(`\[(.*)\]`)
+	configScanner := bufio.NewScanner(agentConfigFile)
+
+	h.Log.Debug("Starting to parse OneAgent config...")
+	for configScanner.Scan(){
+		// This parses the data we retrieved from ruxitagentproc.conf and stores
+		// it into the configFromAgent map of maps that was created above, for easy
+		// merging with configFromAPI later on.
+		currentLine := configScanner.Text()
+
+		// Check if current line is a section header
+		if sectionHeader := sectionRegexp.FindStringSubmatch(currentLine); len(sectionHeader) != 0 {
+			configSection = sectionHeader[1]
+		} else {
+			configSection = ""
+		}
+
+		if configSection != "" {
+			currentSection = configSection
+		} else if strings.HasPrefix(currentLine, "#") { //it's a comment line
+			// skipping over lines that are purely comments
+			continue
+		} else if currentLine == "" {
+			// skipping over empty lines
+			continue
+		} else {
+			// you gotta check if the required map is already there
+			// if not: initialize it with a nice make :-)
+			_, ok := configFromAgent[currentSection]
+			if !ok {
+				configFromAgent[currentSection] = make(map[string]string)
+			}
+			configLineKey := strings.Fields(currentLine)[0]
+			configLineValue := strings.Join(strings.Fields(currentLine)[1:], " ")
+			configFromAgent[currentSection][configLineKey] = configLineValue
+		}
+	}
+	h.Log.Debug("Successfully parsed OneAgent config...")
+
+	// Merge the two configs to get an updated version.
+	// Just writes all of configFromAPI over eventually existing values in
+	// configFromAgent, since the ones from the API are supposed to be the recent ones.
+	// This includes adding possibly new sections and/or property keys.
+	h.Log.Debug("Starting with OneAgent configuration merging...")
+	for section := range configFromAPI {
+		for property := range configFromAPI[section] {
+			_, ok := configFromAgent[section]
+			if !ok {
+				configFromAgent[section] = make(map[string]string)
+			}
+			configFromAgent[section][property] = configFromAPI[section][property]
+		}
+	}
+	h.Log.Debug("Finished OneAgent configuration merging")
+
+	// open ruxitagentproc.conf to overwrite its content
+	overwriteAgentConfigFile, err := os.Create(agentConfigPath)
+	if err != nil {
+		h.Log.Error("Error opening OneAgent config file %s: %s", agentConfigPath, err)
+		return err
+	}
+	h.Log.Debug("Successfully opened OneAgent config file %s for writing", agentConfigPath)
+	defer overwriteAgentConfigFile.Close()
+
+	// write merged data to ruxitagentproc.conf
+	for section := range configFromAgent {
+		fmt.Fprintf(overwriteAgentConfigFile, "[%s]\n", section)
+		for k, v := range configFromAgent[section] {
+			fmt.Fprintf(overwriteAgentConfigFile, "%s %s\n", k, v)
+		}
+		// Trailing empty newline at the end of each section for better human readability
+		fmt.Fprintf(overwriteAgentConfigFile, "\n")
+	}
+	h.Log.Debug("Finished writing updated OneAgent config back to %s", agentConfigPath)
+
+	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # code.cloudfoundry.org/lager v2.0.0+incompatible
 code.cloudfoundry.org/lager
-# github.com/Dynatrace/libbuildpack-dynatrace v1.4.2
+# github.com/Dynatrace/libbuildpack-dynatrace v1.5.0
 github.com/Dynatrace/libbuildpack-dynatrace
 # github.com/Masterminds/semver v1.5.0
 github.com/Masterminds/semver


### PR DESCRIPTION

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
bumped libbuildpack-dynatrace to v1.5.0
updated fake dynatrace api and integration test to take care of the OneAgent config update functionality

* An explanation of the use cases your change solves
Usage of libbuildpack-dyntrace v1.5.0 enables OneAgent config updating during app deployment

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
