### PR TITLE
Scrub multiple ways of describing index-url from requirements.txt

### DIFF
--- a/src/python/supply/supply.go
+++ b/src/python/supply/supply.go
@@ -699,7 +699,7 @@ func (s *Supplier) RunPipVendored() error {
 		installArgs = append(installArgs, "--no-build-isolation")
 	}
 
-	// Remove lines from requirements.txt that begin with -i
+	// Remove lines from requirements.txt that begin with -i, --index-url and --extra-index-url
 	// because specifying index links here makes pip always want internet access,
 	// and pipenv generates requirements.txt with -i.
 	originalReqs, err := ioutil.ReadFile(requirementsPath)
@@ -707,7 +707,7 @@ func (s *Supplier) RunPipVendored() error {
 		return fmt.Errorf("could not read requirements.txt: %v", err)
 	}
 
-	re := regexp.MustCompile(`(?m)^\s*-i.*$`)
+	re := regexp.MustCompile(`(?m)^\s*(-i|--index-url|--extra-index-url)\s+(.*)$`)
 	modifiedReqs := re.ReplaceAll(originalReqs, []byte{})
 	err = ioutil.WriteFile(requirementsPath, modifiedReqs, 0644)
 	if err != nil {


### PR DESCRIPTION
Scrub multiple ways of describing index-url from requirements.txt when using vendored installs

See https://github.com/pypa/pip/issues/11276 for the upstream problem.
A fix was already in-place in the python buildback, but it was limited
to a single notation of `index-url=...`

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
