### PR TITLE
supply: remove pre-installing mercurial

### DIFF
--- a/src/python/supply/supply.go
+++ b/src/python/supply/supply.go
@@ -128,11 +128,6 @@ func RunPython(s *Supplier) error {
 		return err
 	}
 
-	if err := s.HandleMercurial(); err != nil {
-		s.Log.Error("Could not handle pip mercurial dependencies: %v", err)
-		return err
-	}
-
 	if err := s.UninstallUnusedDependencies(); err != nil {
 		s.Log.Error("Error uninstalling unused dependencies: %v", err)
 		return err
@@ -193,25 +188,6 @@ func (s *Supplier) CopyRuntimeTxt() error {
 		if err = libbuildpack.CopyFile(filepath.Join(s.Stager.BuildDir(), "runtime.txt"), filepath.Join(s.Stager.DepDir(), "runtime.txt")); err != nil {
 			return err
 		}
-	}
-	return nil
-}
-
-func (s *Supplier) HandleMercurial() error {
-	if err := s.Command.Execute(s.Stager.BuildDir(), ioutil.Discard, ioutil.Discard, "grep", "-Fiq", "hg+", "requirements.txt"); err != nil {
-		return nil
-	}
-
-	if s.Manifest.IsCached() {
-		s.Log.Warning("Cloud Foundry does not support Pip Mercurial dependencies while in offline-mode. Vendor your dependencies if they do not work.")
-	}
-
-	if err := s.runPipInstall("mercurial"); err != nil {
-		return err
-	}
-
-	if err := s.Stager.LinkDirectoryInDepDir(filepath.Join(s.Stager.DepDir(), "python", "bin"), "bin"); err != nil {
-		return err
 	}
 	return nil
 }

--- a/src/python/supply/supply_test.go
+++ b/src/python/supply/supply_test.go
@@ -456,47 +456,6 @@ var _ = Describe("Supply", func() {
 		})
 	})
 
-	Describe("HandleMercurial", func() {
-		Context("has mercurial dependencies", func() {
-			BeforeEach(func() {
-				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "grep", "-Fiq", "hg+", "requirements.txt")
-			})
-
-			Context("the buildpack is not cached", func() {
-				BeforeEach(func() {
-					mockManifest.EXPECT().IsCached().Return(false)
-				})
-				It("installs mercurial", func() {
-					mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "mercurial")
-					mockStager.EXPECT().LinkDirectoryInDepDir(filepath.Join(depDir, "python", "bin"), "bin")
-					Expect(supplier.HandleMercurial()).To(Succeed())
-				})
-			})
-
-			Context("the buildpack is cached", func() {
-				BeforeEach(func() {
-					mockManifest.EXPECT().IsCached().Return(true)
-				})
-				It("installs mercurial and provides a warning", func() {
-					mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "mercurial")
-					mockStager.EXPECT().LinkDirectoryInDepDir(filepath.Join(depDir, "python", "bin"), "bin")
-					Expect(supplier.HandleMercurial()).To(Succeed())
-					Expect(buffer.String()).To(ContainSubstring("Cloud Foundry does not support Pip Mercurial dependencies while in offline-mode. Vendor your dependencies if they do not work."))
-				})
-			})
-
-		})
-		Context("does not have mercurial dependencies", func() {
-			BeforeEach(func() {
-				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "grep", "-Fiq", "hg+", "requirements.txt").Return(fmt.Errorf("Mercurial not found"))
-			})
-
-			It("succeeds without installing mercurial", func() {
-				Expect(supplier.HandleMercurial()).To(Succeed())
-			})
-		})
-	})
-
 	Describe("RewriteShebangs", func() {
 		BeforeEach(func() {
 			Expect(os.MkdirAll(filepath.Join(depDir, "bin"), 0755)).To(Succeed())


### PR DESCRIPTION
*Edited Fri 8/26 with more details*

### What does this change address?

* There's no documentation that suggests that while installing from
a remote url via a VCS like `hg`, the `mercurial` package should be
pre-installed. [Pip documentation](https://pip.pypa.io/en/latest/topics/vcs-support/) just states that it requires a working
executable to be available, which already exists on the stack.
```
‣ docker run --init -it cloudfoundry/cflinuxfs3 bash -c "hg --version"
Mercurial Distributed SCM (version 4.5.3)
```

* When `fixtures/mercurial` is built by this branch's buildpack,
we can see in the log python-hglib (which was the package referred to in
the testdata by hg clone url) is installed.
```
Successfully installed Flask-2.2.2 ... python-hglib-2.6.2+2.1e7a64588ab0 ...
```

* Git history suggests that pre-installing mercurial via `pip install mercurial` ([link](https://github.com/cloudfoundry/python-buildpack/blob/v1.7.58/src/python/supply/supply.go#L201-L215))
came into this buildpack from the original heroku buildpack fork.
Heroku has since removed it. See https://github.com/heroku/heroku-buildpack-python/pull/1111

### What does this change NOT address?

* This change does not address why running an app with `mercurial` present in
the `requirements.txt` fails with the error pointing to a non-existent include path to
`Python.h` even after include location is set via CFLAGS in 028a7b6.
See [CI log](https://buildpacks.ci.cf-app.com/teams/main/pipelines/python-buildpack/jobs/specs-edge-integration-develop/builds/1054#L62d6d57b:516). The timing of this failure appearing in CI suggests that it's related to the
package using the new setuptools version as a transitive dependency. See #574 
This has to be separately investigated.
