### PR TITLE
Don't warn about script locations

### DIFF
--- a/src/python/supply/supply.go
+++ b/src/python/supply/supply.go
@@ -642,6 +642,7 @@ func (s *Supplier) RunPipUnvendored() error {
 		"--exists-action=w",
 		"--src="+filepath.Join(s.Stager.DepDir(), "src"),
 		"--disable-pip-version-check",
+		"--no-warn-script-location",
 	); err != nil {
 		return fmt.Errorf("could not run pip: %v", err)
 	}
@@ -673,6 +674,7 @@ func (s *Supplier) RunPipVendored() error {
 		"--no-index",
 		"--find-links=file://" + filepath.Join(s.Stager.BuildDir(), "vendor"),
 		"--disable-pip-version-check",
+		"--no-warn-script-location",
 	}
 
 	if s.hasBuildOptions() {

--- a/src/python/supply/supply_test.go
+++ b/src/python/supply/supply_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Supply", func() {
 				Expect(ioutil.WriteFile(filepath.Join(buildDir, "requirements.txt"), []byte{}, 0644)).To(Succeed())
 				mockStager.EXPECT().LinkDirectoryInDepDir(gomock.Any(), gomock.Any())
 
-				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check", "--no-warn-script-location")
 				Expect(supplier.RunPipUnvendored()).To(Succeed())
 			})
 		})
@@ -179,7 +179,7 @@ var _ = Describe("Supply", func() {
 				Expect(ioutil.WriteFile(filepath.Join(buildDir, "requirements.txt"), []byte{}, 0644)).To(Succeed())
 				mockStager.EXPECT().LinkDirectoryInDepDir(gomock.Any(), gomock.Any())
 
-				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check", "--no-warn-script-location")
 				Expect(supplier.RunPipUnvendored()).To(Succeed())
 			})
 		})
@@ -548,7 +548,7 @@ cffi`
 			})
 
 			It("Runs and outputs pip", func() {
-				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check", "--no-warn-script-location")
 				Expect(supplier.RunPipUnvendored()).To(Succeed())
 			})
 		})
@@ -556,7 +556,7 @@ cffi`
 		Context("requirements.txt exists in dep dir and pip install fails", func() {
 			BeforeEach(func() {
 				Expect(ioutil.WriteFile(filepath.Join(buildDir, "requirements.txt"), []byte{}, 0644)).To(Succeed())
-				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check").Return(fmt.Errorf("exit 28"))
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check", "--no-warn-script-location").Return(fmt.Errorf("exit 28"))
 			})
 
 			const proTip = "Running pip install failed. You need to include all dependencies in the vendor directory."
@@ -590,7 +590,7 @@ MarkupSafe==2.0.1
 			})
 
 			It("check index_url, find_links, allow_hosts values", func() {
-				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check", "--no-warn-script-location")
 				Expect(supplier.RunPipUnvendored()).To(Succeed())
 				filePath := filepath.Join(os.Getenv("HOME"), ".pydistutils.cfg")
 				fileContents, err := ioutil.ReadFile(filePath)
@@ -621,7 +621,7 @@ MarkupSafe==2.0.1
 
 			It("installs the vendor directory", func() {
 				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "--no-build-isolation", "-h").Return(nil)
-				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--no-index", fmt.Sprintf("--find-links=file://%s/vendor", buildDir), "--disable-pip-version-check", "--no-build-isolation")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--no-index", fmt.Sprintf("--find-links=file://%s/vendor", buildDir), "--disable-pip-version-check", "--no-warn-script-location", "--no-build-isolation")
 				Expect(supplier.RunPipVendored()).To(Succeed())
 			})
 		})
@@ -631,8 +631,8 @@ MarkupSafe==2.0.1
 				Expect(ioutil.WriteFile(filepath.Join(buildDir, "requirements.txt"), []byte{}, 0644)).To(Succeed())
 				Expect(os.Mkdir(filepath.Join(buildDir, "vendor"), 0755)).To(Succeed())
 				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "--no-build-isolation", "-h").Return(nil)
-				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--no-index", fmt.Sprintf("--find-links=file://%s/vendor", buildDir), "--disable-pip-version-check", "--no-build-isolation").Return(fmt.Errorf("exit 28"))
-				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check").Return(fmt.Errorf("exit 28"))
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--no-index", fmt.Sprintf("--find-links=file://%s/vendor", buildDir), "--disable-pip-version-check", "--no-warn-script-location", "--no-build-isolation").Return(fmt.Errorf("exit 28"))
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "-r", filepath.Join(buildDir, "requirements.txt"), "--ignore-installed", "--exists-action=w", fmt.Sprintf("--src=%s/src", depDir), "--disable-pip-version-check", "--no-warn-script-location").Return(fmt.Errorf("exit 28"))
 			})
 
 			const proTip = "Running pip install failed. You need to include all dependencies in the vendor directory."


### PR DESCRIPTION
See e.g. https://stackoverflow.com/q/59790562/339144 for the confusion these warnings cause.

When installing files into a buildpack, script locations shouldn't matter since these files are presumably not run as scripts anyway (but included as python modules).

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test