### PR TITLE
Fix failing tests (go bp cflinuxfs4 and pip vendor)

### DIFF
--- a/src/python/integration/deploy_python_app_pipenv_test.go
+++ b/src/python/integration/deploy_python_app_pipenv_test.go
@@ -68,9 +68,11 @@ var _ = Describe("deploying a flask web app", func() {
 					app.SetEnv("BP_DEBUG", "1")
 				})
 
-				It("should work by downloading the missing dependency", func() {
-					PushAppAndConfirm(app)
-					Expect(app.GetBody("/")).To(ContainSubstring("Hello, World with pipenv!"))
+				It("should fail because it requires all dependencies to be vendored", func() {
+					Expect(app.Push()).ToNot(Succeed())
+					Expect(app.Stdout.String()).ToNot(ContainSubstring("-----> Installing python"))
+					Expect(app.Stdout.String()).ToNot(ContainSubstring("Running Pip Install (Vendored)"))
+					Expect(app.Stdout.String()).ToNot(ContainSubstring("Running pip install failed. You need to include all dependencies in the vendor directory."))
 				})
 			})
 		})

--- a/src/python/integration/deploy_python_app_with_dynatrace_test.go
+++ b/src/python/integration/deploy_python_app_with_dynatrace_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
@@ -26,7 +27,11 @@ var _ = Describe("CF Python Buildpack", func() {
 		}
 
 		dynatraceAPI = cutlass.New(Fixtures("fake_dynatrace_api"))
-
+		// TODO: remove this once go-buildpack runs on cflinuxfs4
+		// This is done to have the dynatrace broker app written in go up and running
+		if os.Getenv("CF_STACK") == "cflinuxfs4" {
+			dynatraceAPI.Stack = "cflinuxfs3"
+		}
 		dynatraceAPI.SetEnv("BP_DEBUG", "true")
 
 		Expect(dynatraceAPI.Push()).To(Succeed())


### PR DESCRIPTION
# Changes
- Revert the change until Go Buildpack (cflinuxfs4) is available on cf environments.
- Update integration tests to reflect the changes introduced in #638 when an app is not fully vendored.