### PR TITLE
Add special case for CFLAGS dir when using Python 3.7

### DIFF
--- a/src/python/supply/supply.go
+++ b/src/python/supply/supply.go
@@ -284,8 +284,16 @@ func (s *Supplier) InstallPython() error {
 	}
 
 	version := regexp.MustCompile(`\d+\.\d+`).FindString(dep.Version)
-	if err := os.Setenv("CFLAGS", fmt.Sprintf("-I%s", filepath.Join(s.Stager.DepDir(), "python", "include", fmt.Sprintf("python%s", version)))); err != nil {
-		return err
+
+	//Remove once Python 3.7 is out of support (June 2023)
+	if version == "3.7" {
+		if err := os.Setenv("CFLAGS", fmt.Sprintf("-I%s", filepath.Join(s.Stager.DepDir(), "python", "include", fmt.Sprintf("python%sm", version)))); err != nil {
+			return err
+		}
+	} else {
+		if err := os.Setenv("CFLAGS", fmt.Sprintf("-I%s", filepath.Join(s.Stager.DepDir(), "python", "include", fmt.Sprintf("python%s", version)))); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/src/python/supply/supply_test.go
+++ b/src/python/supply/supply_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Supply", func() {
 			pythonInstallDir = filepath.Join(depDir, "python")
 			Expect(os.WriteFile(filepath.Join(depDir, "runtime.txt"), []byte("\n\n\npython-3.4.2\n\n\n"), 0644)).To(Succeed())
 
-			versions = []string{"3.4.2"}
+			versions = []string{"3.4.2", "3.7.13"}
 			originalPath = os.Getenv("PATH")
 		})
 
@@ -113,6 +113,24 @@ var _ = Describe("Supply", func() {
 				Expect(os.Getenv("PATH")).To(Equal(fmt.Sprintf("%s:%s", filepath.Join(depDir, "bin"), originalPath)))
 				Expect(os.Getenv("PYTHONPATH")).To(Equal(depDir))
 				Expect(os.Getenv("CFLAGS")).To(Equal(fmt.Sprintf("-I%s", filepath.Join(depDir, "python", "include", "python3.4"))))
+			})
+		})
+
+		//Remove once Python 3.7 is out of support (June 2023)
+		Context("runtime.txt sets Python version 3.7", func() {
+			BeforeEach(func() {
+				Expect(os.RemoveAll(filepath.Join(depDir, "runtime.txt"))).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(depDir, "runtime.txt"), []byte("\n\n\npython-3.7.13\n\n\n"), 0644)).To(Succeed())
+			})
+			It("installs Python version 3.7", func() {
+				mockManifest.EXPECT().AllDependencyVersions("python").Return(versions)
+				mockInstaller.EXPECT().InstallDependency(libbuildpack.Dependency{Name: "python", Version: "3.7.13"}, pythonInstallDir)
+				mockStager.EXPECT().LinkDirectoryInDepDir(filepath.Join(pythonInstallDir, "bin"), "bin")
+				mockStager.EXPECT().LinkDirectoryInDepDir(filepath.Join(pythonInstallDir, "lib"), "lib")
+				Expect(supplier.InstallPython()).To(Succeed())
+				Expect(os.Getenv("PATH")).To(Equal(fmt.Sprintf("%s:%s", filepath.Join(depDir, "bin"), originalPath)))
+				Expect(os.Getenv("PYTHONPATH")).To(Equal(depDir))
+				Expect(os.Getenv("CFLAGS")).To(Equal(fmt.Sprintf("-I%s", filepath.Join(depDir, "python", "include", "python3.7m"))))
 			})
 		})
 


### PR DESCRIPTION
Slight difference in naming between the directories in the python 3.7 dependency vs other versions (3.7 has a dir named `include/python3.7m` vs `include/python3.x`) results in build failures when using `pip` dependencies which rely on `CFLAGS` being set. These changes allow the buildpack to account for that difference when setting `CFLAGS`.

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
