### PR TITLE
Remove mercurial tests (not supported anymore)

### DIFF
--- a/src/python/integration/miscellaneous_test.go
+++ b/src/python/integration/miscellaneous_test.go
@@ -103,28 +103,6 @@ func testMiscellaneous(platform switchblade.Platform, fixtures string) func(*tes
 			})
 		})
 
-		context("when pushing an app with mercurial dependencies", func() {
-			it.Before(func() {
-				var err error
-				source, err = switchblade.Source(filepath.Join(fixtures, "miscellaneous", "mercurial"))
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			it.After(func() {
-				Expect(os.RemoveAll(source)).To(Succeed())
-			})
-
-			it("deploys successfully", func() {
-				deployment, logs, err := platform.Deploy.
-					Execute(name, source)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(deployment).Should(Serve(ContainSubstring("Hello, World!")))
-
-				Eventually(logs.String).Should(ContainSubstring("Obtaining python-hglib"))
-			})
-		})
-
 		context("when pushing an app without a Procfile", func() {
 			context("when start command is specified in push", func() {
 				it.Before(func() {


### PR DESCRIPTION
# Context

In #575 we removed mercurial logic from the Buildpack since It only requires the executable (hg) and It was included in the stack.

in https://github.com/cloudfoundry/cflinuxfs4/pull/2 we removed any reference to Python from the cflinuxfs4 stack (mercurial included) and:

1. We are not going to add mercurial to the stack.
2. We are not going to install mercurial in the Buildpack.