### PR TITLE
Pin mysqlclient version in brats fixtures

### DIFF
--- a/fixtures/brats/requirements.txt
+++ b/fixtures/brats/requirements.txt
@@ -6,4 +6,4 @@ itsdangerous
 bcrypt
 hiredis
 psycopg2
-mysqlclient
+mysqlclient==2.1.1


### PR DESCRIPTION
# Context

The `mysqlclient` pip package got updated from `v2.1.1` to `v2.2.0` and introduces a braking change. It changes the way the pip package is configured (ref https://github.com/PyMySQL/mysqlclient/pull/586) and now requires `pkg-config` to be installed. This workaround doesn't work as intended in cflinuxfs3 (only works in cflinuxfs4)

# Solution

Pin the version of `mysqlclient` to `v2.1.1`