### PR TITLE
Use cflinuxfs4 for testing

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: stable
 
@@ -51,7 +51,7 @@ jobs:
     steps:
 
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: stable
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19.x
+          go-version: stable
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19.x
+          go-version: stable
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "stack": "cflinuxfs3",
+  "stack": "cflinuxfs4",
   "oses": [
     "linux"
   ],

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/cloudfoundry/python-buildpack
 
+go 1.22.5
+
 require (
 	github.com/Dynatrace/libbuildpack-dynatrace v1.5.2
 	github.com/blang/semver v3.5.1+incompatible
@@ -50,5 +52,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-go 1.19

--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -12,8 +12,8 @@ function main() {
   fi
 
   local version expected_sha dir
-  version="1.19"
-  expected_sha="7e231ea5c68f4be7fea916d27814cc34b95e78c4664c3eb2411e8370f87558bd"
+  version="1.22.5"
+  expected_sha="ddb12ede43eef214c7d4376761bd5ba6297d5fa7a06d5635ea3e7a276b3db730"
   dir="/tmp/go${version}"
 
   mkdir -p "${dir}"


### PR DESCRIPTION
- the tests do not run on cflinuxfs3 with a recent version of go
- this is due to the following reasons:
  * we bumped to the most recent version of go (1.22)
  * go 1.20 and higher dropped support for older versions of glibc when dynamically linking
  * we dynamically link the buildpackapplifecycle (v2 lifecycle) as part of the switchblade setup
  * therefore the BAL no longer runs on cflinuxfs3
- Alternatively, we could statically link the BAL when we build it in switchblade. But that is more work, and it is fine to only test against one stack in these tests, and there is not reason we should pick cflinuxfs3 over cflinuxfs4
