### PR TITLE
[SEALIGHTS] Add SL_VERSION environment variable support

### DIFF
--- a/src/python/hooks/sealights.go
+++ b/src/python/hooks/sealights.go
@@ -41,6 +41,7 @@ func NewSealightsConfig() *SealightsConfig {
 		BsIdFile:  "",
 		Proxy:     "",
 		LabId:     "",
+		Version:   "",
 	}
 }
 
@@ -57,6 +58,7 @@ func (sc *SealightsConfig) parseSealightsPlan(plan SealightsPlan) *SealightsConf
 	sc.BsIdFile = sc.getEnv("SL_BUILD_SESSION_ID_FILE", plan.Credentials.BsIdFile)
 	sc.Proxy = sc.getEnv("SL_PROXY", plan.Credentials.Proxy)
 	sc.LabId = sc.getEnv("SL_LAB_ID", plan.Credentials.LabId)
+	sc.Version = sc.getEnv("SL_VERSION", plan.Credentials.Version)
 	return sc
 }
 


### PR DESCRIPTION
Introduce support for the SL_VERSION environment variable in the Sealights configuration. This allows the configuration to include versioning information, enhancing the traceability and management of different builds.

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* [ x] I have viewed signed and have submitted the Contributor License Agreement

* [ x ] I have made this pull request to the `develop` branch

* [  x ] I have added an integration test
