### PR TITLE
Upgrade Switchblade to v0.9.2 for CF API v3 compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Dynatrace/libbuildpack-dynatrace v1.8.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20240717165421-f2ae8069fcba
-	github.com/cloudfoundry/switchblade v0.9.1
+	github.com/cloudfoundry/switchblade v0.9.2
 	github.com/golang/mock v1.6.0
 	github.com/kr/text v0.2.0
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -746,8 +746,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudfoundry/libbuildpack v0.0.0-20240717165421-f2ae8069fcba h1:RdbOeYpXLO3wdrQrKuQFUIl7aLx6cdk95Lh/uFwAA9c=
 github.com/cloudfoundry/libbuildpack v0.0.0-20240717165421-f2ae8069fcba/go.mod h1:kn4FHMwI8bTd9gT92wPGjXHzUvGcj8CkPxG8q3AGBAQ=
-github.com/cloudfoundry/switchblade v0.9.1 h1:WHEUhSnkoqCJOkqJ1WD3XcmKztpYmagdIWT+GJf6Gfc=
-github.com/cloudfoundry/switchblade v0.9.1/go.mod h1:hIEQdGAsuNnzlyQfsD5OIORt38weSBar6Wq5/JX6Omo=
+github.com/cloudfoundry/switchblade v0.9.2 h1:b2lwxrAblg9uKncNQRKZ09/teuKdZIixcENKgrLQPjo=
+github.com/cloudfoundry/switchblade v0.9.2/go.mod h1:hIEQdGAsuNnzlyQfsD5OIORt38weSBar6Wq5/JX6Omo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/src/python/integration/versions_test.go
+++ b/src/python/integration/versions_test.go
@@ -1,12 +1,13 @@
 package integration_test
 
 import (
-	"github.com/blang/semver"
-	"github.com/cloudfoundry/libbuildpack"
 	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
+
+	"github.com/blang/semver"
+	"github.com/cloudfoundry/libbuildpack"
 
 	"github.com/cloudfoundry/switchblade"
 	"github.com/sclevine/spec"

--- a/vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/stage.go
+++ b/vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/stage.go
@@ -35,6 +35,21 @@ func (s Stage) Run(logs io.Writer, home, name string) (string, error) {
 		Env:    env,
 	})
 	if err != nil {
+		// In CF API v3, staging failure logs are not automatically captured in stdout/stderr
+		// We need to fetch them explicitly using 'cf logs --recent'
+		recentLogs := bytes.NewBuffer(nil)
+		logErr := s.cli.Execute(pexec.Execution{
+			Args:   []string{"logs", name, "--recent"},
+			Stdout: recentLogs,
+			Stderr: recentLogs,
+			Env:    env,
+		})
+		if logErr == nil && recentLogs.Len() > 0 {
+			// Append recent logs to the main logs buffer
+			_, _ = logs.Write([]byte("\n--- Recent Logs (cf logs --recent) ---\n"))
+			_, _ = logs.Write(recentLogs.Bytes())
+		}
+
 		return "", fmt.Errorf("failed to start: %w\n\nOutput:\n%s", err, logs)
 	}
 

--- a/vendor/github.com/cloudfoundry/switchblade/random_name.go
+++ b/vendor/github.com/cloudfoundry/switchblade/random_name.go
@@ -13,5 +13,9 @@ func RandomName() (string, error) {
 		return "", err
 	}
 
+	// Replace underscores with hyphens to make the name DNS-safe
+	// Cloud Foundry uses app names in DNS URLs where underscores are not allowed
+	id = strings.ReplaceAll(id, "_", "-")
+
 	return strings.ToLower(fmt.Sprintf("switchblade-%s", id)), nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -30,7 +30,7 @@ github.com/cloudfoundry/libbuildpack/cutlass/docker
 github.com/cloudfoundry/libbuildpack/cutlass/glow
 github.com/cloudfoundry/libbuildpack/packager
 github.com/cloudfoundry/libbuildpack/snapshot
-# github.com/cloudfoundry/switchblade v0.9.1
+# github.com/cloudfoundry/switchblade v0.9.2
 ## explicit; go 1.23.0
 github.com/cloudfoundry/switchblade
 github.com/cloudfoundry/switchblade/internal/cloudfoundry


### PR DESCRIPTION
Upgrades Switchblade to v0.9.2
Includes the CF API v3 log capture fix
