### PR TITLE
Remove obsolete stack cflinuxfs3, python v3.9.x, pipenv v2024.4.1

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -24,16 +24,11 @@ dependency_deprecation_dates:
   name: python
   date: 2030-10-31
   link: https://peps.python.org/pep-0745/
-- version_line: 3.9.x
-  name: python
-  date: 2025-10-05
-  link: https://www.python.org/dev/peps/pep-0596/
 dependencies:
 - name: libffi
   version: 3.2.1
   cf_stacks:
   - cflinuxfs4
-  - cflinuxfs3
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/python/libffi-3.2.1-linux-x64-5f5bf32c.tgz
   sha256: ff6f2f33aa3d3978a2c1764d6992ac8c384bc84a4c5d193deef891eef2555dc9
   source: https://sourceware.org/ftp/libffi/libffi-3.2.1.tar.gz
@@ -42,7 +37,6 @@ dependencies:
   version: 1.0.18
   cf_stacks:
   - cflinuxfs4
-  - cflinuxfs3
   uri: https://buildpacks.cloudfoundry.org/dependencies/manual-binaries/python/libmemcache-1.0.18-linux-x64-6d33aa02.tgz
   sha256: '009a3476197030e30d0ce924cc044ee4851ef27324e132b29fd12d8cde071915'
   source: https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz
@@ -53,7 +47,6 @@ dependencies:
   sha256: 790e8ea347cf49ba250fceacdc0b022237a9150717b9e4c17f2e70abc075c05d
   cf_stacks:
   - cflinuxfs4
-  - cflinuxfs3
   source: https://github.com/conda/conda/archive/25.7.0.tar.gz
   source_sha256: 790e8ea347cf49ba250fceacdc0b022237a9150717b9e4c17f2e70abc075c05d
 - name: miniforge
@@ -62,7 +55,6 @@ dependencies:
   sha256: b64f77042cf8eafd31ced64f9253a74fb85db63545fe167ba5756aea0e8125be
   cf_stacks:
   - cflinuxfs4
-  - cflinuxfs3
   source: https://github.com/conda-forge/miniforge/archive/refs/tags/24.7.1-0.tar.gz
   source_sha256: ca2f3cea67d6a1dbfd6acb9743891014768b12ad774755c57fbbcbfcd1fd8200
 - name: pip
@@ -78,7 +70,6 @@ dependencies:
   sha256: 7dc1e9882eb18f53150261c3a0cde7d5a39cdb18843c930ee01db8582f6b4f27
   cf_stacks:
   - cflinuxfs4
-  - cflinuxfs3
   source: https://files.pythonhosted.org/packages/20/16/650289cd3f43d5a2fadfd98c68bd1e1e7f2550a1a5326768cddfbcedb2c5/pip-25.2.tar.gz
   source_sha256: 578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2
 - name: pip
@@ -89,14 +80,6 @@ dependencies:
   source: https://files.pythonhosted.org/packages/fe/6e/74a3f0179a4a73a53d66ce57fdb4de0080a8baa1de0063de206d6167acc2/pip-25.3.tar.gz
   source_sha256: 8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343
 - name: pipenv
-  version: 2024.4.1
-  uri: https://buildpacks.cloudfoundry.org/dependencies/pipenv/pipenv_2024.4.1_linux_noarch_cflinuxfs3_b3c74c78.tgz
-  sha256: b3c74c78ef410ef910ca203f788cb5b0e095fa06b63e47ebc095b2785cc44c01
-  cf_stacks:
-  - cflinuxfs3
-  source: https://files.pythonhosted.org/packages/ca/5b/8ce5227713d692913c186d9a3164eee0236fbc3eaca87d7e2bd5dbb1da36/pipenv-2024.4.1.tar.gz
-  source_sha256: e8ea6105c1cdda7d5c19df7bd6439a006751f3d4e017602c791e7b51314adf84
-- name: pipenv
   version: 2026.0.3
   uri: https://buildpacks.cloudfoundry.org/dependencies/pipenv/pipenv_2026.0.3_linux_noarch_cflinuxfs4_082d293b.tgz
   sha256: '082d293bd8ab79b4674af1aa3812a6488654ad87e07cec63d73d67f9fbbdc131'
@@ -104,30 +87,6 @@ dependencies:
   - cflinuxfs4
   source: https://files.pythonhosted.org/packages/90/03/8958464e0d366530477f07fd041ef6b9df56f3ea9c56d0db24cc8cd87fff/pipenv-2026.0.3.tar.gz
   source_sha256: 9a39d13a41ed8e4368ad50620941191f357319c8ffb7df45875c7c5dc6604ff6
-- name: python
-  version: 3.9.24
-  uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.9.24_linux_x64_cflinuxfs3_e7fcaa7e.tgz
-  sha256: e7fcaa7ebfab1610a902c86a886515b8db074039284bdf6deb54353d664a5e79
-  cf_stacks:
-  - cflinuxfs3
-  source: https://www.python.org/ftp/python/3.9.24/Python-3.9.24.tgz
-  source_sha256: 9a32cfc683aecaadbd9ed891ac2af9451ff37f48a00a2d8e1f4ecd9c2a1ffdcb
-- name: python
-  version: 3.9.25
-  uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.9.25_linux_x64_cflinuxfs4_47183960.tgz
-  sha256: 47183960e453a25d6e30b763a6e868f812b58234ba747f2a380c241109b8856c
-  cf_stacks:
-  - cflinuxfs4
-  source: https://www.python.org/ftp/python/3.9.25/Python-3.9.25.tgz
-  source_sha256: a7438eabd3a48139f42d4e058096af8d880b0bb6e8fb8c78838892e4ce5583f2
-- name: python
-  version: 3.10.19
-  uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.10.19_linux_x64_cflinuxfs3_d754b71d.tgz
-  sha256: d754b71d6ee49fa556e22a0cf8370ab822716f0571eff5024fbc1d5918dd2ee6
-  cf_stacks:
-  - cflinuxfs3
-  source: https://www.python.org/ftp/python/3.10.19/Python-3.10.19.tgz
-  source_sha256: a078fb2d7a216071ebbe2e34b5f5355dd6b6e9b0cd1bacc4a41c63990c5a0eec
 - name: python
   version: 3.10.19
   uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.10.19_linux_x64_cflinuxfs4_b9b2cdae.tgz
@@ -138,28 +97,12 @@ dependencies:
   source_sha256: a078fb2d7a216071ebbe2e34b5f5355dd6b6e9b0cd1bacc4a41c63990c5a0eec
 - name: python
   version: 3.11.14
-  uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.11.14_linux_x64_cflinuxfs3_294394be.tgz
-  sha256: 294394be5406d1f8a507672445d57ef4a6ae7398839b47832d29ac0aba8508de
-  cf_stacks:
-  - cflinuxfs3
-  source: https://www.python.org/ftp/python/3.11.14/Python-3.11.14.tgz
-  source_sha256: 563d2a1b2a5ba5d5409b5ecd05a0e1bf9b028cf3e6a6f0c87a5dc8dc3f2d9182
-- name: python
-  version: 3.11.14
   uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.11.14_linux_x64_cflinuxfs4_66f53248.tgz
   sha256: 66f532488f868c421702755ad9e1e65e802b48f3881f1d198d66f9ff52ea463e
   cf_stacks:
   - cflinuxfs4
   source: https://www.python.org/ftp/python/3.11.14/Python-3.11.14.tgz
   source_sha256: 563d2a1b2a5ba5d5409b5ecd05a0e1bf9b028cf3e6a6f0c87a5dc8dc3f2d9182
-- name: python
-  version: 3.12.10
-  uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.12.10_linux_x64_cflinuxfs3_c91697d7.tgz
-  sha256: c91697d70ad221408a586cb3ac6efc6dfa45ec4eda6f1375c9a38f12f9f3e403
-  cf_stacks:
-  - cflinuxfs3
-  source: https://www.python.org/ftp/python/3.12.10/Python-3.12.10.tgz
-  source_sha256: 15d9c623abfd2165fe816ea1fb385d6ed8cf3c664661ab357f1782e3036a6dac
 - name: python
   version: 3.12.12
   uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.12.12_linux_x64_cflinuxfs4_3ae569b8.tgz
@@ -169,14 +112,6 @@ dependencies:
   source: https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz
   source_sha256: 487c908ddf4097a1b9ba859f25fe46d22ccaabfb335880faac305ac62bffb79b
 - name: python
-  version: 3.13.9
-  uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.13.9_linux_x64_cflinuxfs3_1c04ba8c.tgz
-  sha256: 1c04ba8c1c4eaa86834888d4e8291189674c1f7508cfac850c2c9ccec13c79a3
-  cf_stacks:
-  - cflinuxfs3
-  source: https://www.python.org/ftp/python/3.13.9/Python-3.13.9.tgz
-  source_sha256: c4c066af19c98fb7835d473bebd7e23be84f6e9874d47db9e39a68ee5d0ce35c
-- name: python
   version: 3.13.11
   uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.13.11_linux_x64_cflinuxfs4_04d6f5a2.tgz
   sha256: 04d6f5a205d857a9d0d079d2784ca1201058ad8e22df14c311ca5cecf0ba58bf
@@ -184,14 +119,6 @@ dependencies:
   - cflinuxfs4
   source: https://www.python.org/ftp/python/3.13.11/Python-3.13.11.tgz
   source_sha256: 03cfedbe06ce21bc44ce09245e091a77f2fee9ec9be5c52069048a181300b202
-- name: python
-  version: 3.14.2
-  uri: https://buildpack-dependencies.tanzu.vmware.com/cf/python/python_3.14.2_linux_x64_cflinuxfs3_82c1798d.tgz
-  sha256: 82c1798db9c1af3c4e6bd589cb1016b3c38981f809a63338f6708d6385c6e97b
-  cf_stacks:
-  - cflinuxfs3
-  source: https://www.python.org/ftp/python/3.14.2/Python-3.14.2.tgz
-  source_sha256: c609e078adab90e2c6bacb6afafacd5eaf60cd94cf670f1e159565725fcd448d
 - name: python
   version: 3.14.2
   uri: https://buildpack-dependencies.tanzu.vmware.com/cf/python/python_3.14.2_linux_x64_cflinuxfs4_f32bebd1.tgz
@@ -206,7 +133,6 @@ dependencies:
   sha256: db9ec7d3c1b8e1494852b7228c3de7dd7449a1c4a53297ea9633a117eedf6787
   cf_stacks:
   - cflinuxfs4
-  - cflinuxfs3
   source: https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz
   source_sha256: f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
 include_files:


### PR DESCRIPTION
## Remove obsolete cflinuxfs3 stack and outdated Python versions
### Summary
This PR cleans up the `manifest.yml` by removing all dependencies for the obsolete `cflinuxfs3` stack and removing Python 3.9.x versions that are no longer actively maintained.

### Changes Made
1. Removed cflinuxfs3 stack support
2. Removed Python 3.9.x versions - Python 3.9 reached end-of-life on October 5, 2025


3. Removed obsolete dependency versions - pipenv 2024.4.1 (cflinuxfs3) - superseded by pipenv 2026.0.3
4. Older Python versions for cflinuxfs3:
 - python 3.10.19 (cflinuxfs3)
 - python 3.11.14 (cflinuxfs3)
 - python 3.12.10 (cflinuxfs3)
 - python 3.13.9 (cflinuxfs3)
 - python 3.14.2 (cflinuxfs3)

### Rationale
cflinuxfs3 is obsolete: cflinuxfs4 is the current supported stack
Python 3.9 is EOL: Reached end-of-life on October 5, 2025 (per PEP 596)
