### PR TITLE
Remove Python version 3.12.10 due to vulnerability

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -153,14 +153,6 @@ dependencies:
   source: https://www.python.org/ftp/python/3.11.14/Python-3.11.14.tgz
   source_sha256: 563d2a1b2a5ba5d5409b5ecd05a0e1bf9b028cf3e6a6f0c87a5dc8dc3f2d9182
 - name: python
-  version: 3.12.10
-  uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.12.10_linux_x64_cflinuxfs3_c91697d7.tgz
-  sha256: c91697d70ad221408a586cb3ac6efc6dfa45ec4eda6f1375c9a38f12f9f3e403
-  cf_stacks:
-  - cflinuxfs3
-  source: https://www.python.org/ftp/python/3.12.10/Python-3.12.10.tgz
-  source_sha256: 15d9c623abfd2165fe816ea1fb385d6ed8cf3c664661ab357f1782e3036a6dac
-- name: python
   version: 3.12.12
   uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_3.12.12_linux_x64_cflinuxfs4_3ae569b8.tgz
   sha256: 3ae569b8d1c5cd557fcf729153a86bbfaa0469e96390b67e6de24672b720d9e2


### PR DESCRIPTION
Removed deprecated Python 3.12.10 entry due to vulnerability
