### PR TITLE
feat: Add poetry-core support

### DIFF
--- a/src/python/supply/supply.go
+++ b/src/python/supply/supply.go
@@ -747,14 +747,14 @@ func (s *Supplier) InstallCommonBuildDependencies() error {
 	if err := s.Installer.InstallOnlyVersion("pip", tempPath); err != nil {
 		return err
 	}
-	if err := s.Installer.InstallOnlyVersion("flit-core", tempPath); err != nil {
-		return err
-	}
-
-	s.Log.Info("Installing build-time dependency flit-core (bootstrap)")
-	args := []string{tempPath, "--no-build-isolation"}
-	if err := s.runPipInstall(args...); err != nil {
-		return fmt.Errorf("could not bootstrap-install flit-core: %v", err)
+	for _, dep := range []string{"flit-core", "poetry-core"} {
+		if err := s.Installer.InstallOnlyVersion(dep, tempPath); err != nil {
+			return fmt.Errorf("could not prepare build-time dependency %s: %v", dep, err)
+		}
+		s.Log.Info("Installing build-time dependency %s (bootstrap)", dep)
+		if err := s.runPipInstall(tempPath, "--no-build-isolation"); err != nil {
+			return fmt.Errorf("could not bootstrap-install %s: %v", dep, err)
+		}
 	}
 
 	for _, dep := range []string{"wheel", "setuptools"} {
@@ -764,6 +764,8 @@ func (s *Supplier) InstallCommonBuildDependencies() error {
 			return fmt.Errorf("could not install build-time dependency %s: %v", dep, err)
 		}
 	}
+
+
 	return nil
 }
 

--- a/src/python/supply/supply_test.go
+++ b/src/python/supply/supply_test.go
@@ -633,9 +633,11 @@ MarkupSafe==2.0.1
 
 	Describe("InstallCommonBuildDependencies", func() {
 		Context("successful installation", func() {
-			It("bootstraps flit-core, wheel and setuptools", func() {
+			It("bootstraps flit-core, poetry-core, wheel and setuptools", func() {
 				mockInstaller.EXPECT().InstallOnlyVersion("pip", "/tmp/common_build_deps")
 				mockInstaller.EXPECT().InstallOnlyVersion("flit-core", "/tmp/common_build_deps")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "/tmp/common_build_deps", "--no-build-isolation")
+				mockInstaller.EXPECT().InstallOnlyVersion("poetry-core", "/tmp/common_build_deps")
 				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "/tmp/common_build_deps", "--no-build-isolation")
 				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "wheel", "--no-index", "--no-build-isolation", "--upgrade-strategy=only-if-needed", "--find-links=/tmp/common_build_deps")
 				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "setuptools", "--no-index", "--no-build-isolation", "--upgrade-strategy=only-if-needed", "--find-links=/tmp/common_build_deps")
@@ -644,19 +646,42 @@ MarkupSafe==2.0.1
 			})
 		})
 
-	Context("flit-core bootstrap fails", func() {
-		It("returns a useful error message", func() {
-			mockInstaller.EXPECT().InstallOnlyVersion("pip", "/tmp/common_build_deps")
-			mockInstaller.EXPECT().InstallOnlyVersion("flit-core", "/tmp/common_build_deps")
-			mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "/tmp/common_build_deps", "--no-build-isolation").Return(fmt.Errorf("bootstrap-error"))
-			Expect(supplier.InstallCommonBuildDependencies()).To(MatchError("could not bootstrap-install flit-core: bootstrap-error"))
+		Context("flit-core bootstrap fails", func() {
+			It("returns a useful error message", func() {
+				mockInstaller.EXPECT().InstallOnlyVersion("pip", "/tmp/common_build_deps")
+				mockInstaller.EXPECT().InstallOnlyVersion("flit-core", "/tmp/common_build_deps")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "/tmp/common_build_deps", "--no-build-isolation").Return(fmt.Errorf("bootstrap-error"))
+				Expect(supplier.InstallCommonBuildDependencies()).To(MatchError("could not bootstrap-install flit-core: bootstrap-error"))
+			})
 		})
-	})
+
+		Context("poetry-core preparation fails", func() {
+			It("returns a useful error message", func() {
+				mockInstaller.EXPECT().InstallOnlyVersion("pip", "/tmp/common_build_deps")
+				mockInstaller.EXPECT().InstallOnlyVersion("flit-core", "/tmp/common_build_deps")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "/tmp/common_build_deps", "--no-build-isolation")
+				mockInstaller.EXPECT().InstallOnlyVersion("poetry-core", "/tmp/common_build_deps").Return(fmt.Errorf("prepare-error"))
+				Expect(supplier.InstallCommonBuildDependencies()).To(MatchError("could not prepare build-time dependency poetry-core: prepare-error"))
+			})
+		})
+
+		Context("poetry-core bootstrap fails", func() {
+			It("returns a useful error message", func() {
+				mockInstaller.EXPECT().InstallOnlyVersion("pip", "/tmp/common_build_deps")
+				mockInstaller.EXPECT().InstallOnlyVersion("flit-core", "/tmp/common_build_deps")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "/tmp/common_build_deps", "--no-build-isolation")
+				mockInstaller.EXPECT().InstallOnlyVersion("poetry-core", "/tmp/common_build_deps")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "/tmp/common_build_deps", "--no-build-isolation").Return(fmt.Errorf("poetry-error"))
+				Expect(supplier.InstallCommonBuildDependencies()).To(MatchError("could not bootstrap-install poetry-core: poetry-error"))
+			})
+		})
 
 		Context("wheel installation fails", func() {
 			It("returns a useful error message", func() {
 				mockInstaller.EXPECT().InstallOnlyVersion("pip", "/tmp/common_build_deps")
 				mockInstaller.EXPECT().InstallOnlyVersion("flit-core", "/tmp/common_build_deps")
+				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "/tmp/common_build_deps", "--no-build-isolation")
+				mockInstaller.EXPECT().InstallOnlyVersion("poetry-core", "/tmp/common_build_deps")
 				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "/tmp/common_build_deps", "--no-build-isolation")
 				mockCommand.EXPECT().Execute(buildDir, gomock.Any(), gomock.Any(), "python", "-m", "pip", "install", "wheel", "--no-index", "--no-build-isolation", "--upgrade-strategy=only-if-needed", "--find-links=/tmp/common_build_deps").Return(fmt.Errorf("some-pip-error"))
 				Expect(supplier.InstallCommonBuildDependencies()).To(MatchError("could not install build-time dependency wheel: some-pip-error"))


### PR DESCRIPTION
## Add poetry-core bootstrap support for offline/vendored Python app deployments

### Problem

When deploying a Python application with vendored dependencies (sdists) to Cloud Foundry, the buildpack fails with:

```
pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'poetry.core.masonry.api'
```

This happens because modern Python packages declare their **build-time dependencies** in `pyproject.toml` according to [PEP 517](https://peps.python.org/pep-0517/). For example, `flask-healthz` declares:

```toml
[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
```

When pip installs a package from a source distribution (sdist) **online**, it automatically downloads and installs any declared build backends. In an **offline/vendored** deployment (`--no-index`), pip cannot fetch them — and since pip 23.1 enforces PEP 517 strictly (no longer falling back to the legacy `setup.py install` method), the build fails entirely.

### Root Cause

The buildpack's `InstallCommonBuildDependencies()` function already bootstraps  `setuptools`/`wheel` (used by Click, CacheLib, etc.). However, `poetry-core` — used by `flask-healthz` and other Poetry-managed packages — was not handled.

poetry-core cannot be added to the app's `vendor/` directory as a workaround because pip treats `vendor/` as **runtime** dependencies to install, not as build backends to invoke during the build process.

### Solution

Ship `poetry-core` as a normal buildpack dependency, just like the other packaged dependencies. The tarball still lives inside the buildpack, but it is now declared in `manifest.yml` and installed through `Installer.InstallOnlyVersion("poetry-core", "/tmp/common_build_deps")` before the bootstrap install:

```
pip install /tmp/common_build_deps --no-build-isolation
```

This keeps `poetry-core` on the standard manifest/installer path instead of special-casing manual tar extraction in `supply.go`.


After these steps, pip can successfully build any app sdist that uses `flit-core`, `setuptools`, or `poetry-core` as its build backend — fully offline.

### Testing

Verified with a Flask application using all-sdist-vendored dependencies, including `flask-healthz==1.0.1`. All 13 packages installed successfully from source during staging with no internet access to PyPI.

### Dependecy
Depends on https://github.com/cloudfoundry/buildpacks-ci/pull/621 & https://github.com/cloudfoundry/python-buildpack/pull/1156

### Fix
https://github.com/cloudfoundry/python-buildpack/issues/165